### PR TITLE
Query validator info

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -28513,6 +28513,207 @@ paths:
                         }
       tags:
         - Query
+  '/volumefi/cronchain/valset/validator_info/{valAddr}':
+    get:
+      summary: Queries a list of ValidatorInfo items.
+      operationId: VolumefiCronchainValsetValidatorInfo
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                  additionalProperties: {}
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+
+                     Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                     Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := anypb.New(foo)
+                         if err != nil {
+                           ...
+                         }
+                         ...
+                         foo := &pb.Foo{}
+                         if err := any.UnmarshalTo(foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+
+                    JSON
+
+                    ====
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: valAddr
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
 definitions:
   cosmos.auth.v1beta1.Params:
     type: object
@@ -48205,6 +48406,13 @@ definitions:
         description: params holds all the parameters of this module.
         type: object
     description: QueryParamsResponse is response type for the Query/Params RPC method.
+  volumefi.cronchain.valset.MsgAddExternalChainInfoForValidator.ChainInfo:
+    type: object
+    properties:
+      chainID:
+        type: string
+      address:
+        type: string
   volumefi.cronchain.valset.MsgAddExternalChainInfoForValidatorResponse:
     type: object
   volumefi.cronchain.valset.MsgRegisterConductorResponse:
@@ -48219,3 +48427,5 @@ definitions:
         description: params holds all the parameters of this module.
         type: object
     description: QueryParamsResponse is response type for the Query/Params RPC method.
+  volumefi.cronchain.valset.QueryValidatorInfoResponse:
+    type: object

--- a/proto/valset/query.proto
+++ b/proto/valset/query.proto
@@ -5,6 +5,7 @@ import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "valset/params.proto";
+import "valset/snapshot.proto";
 // this line is used by starport scaffolding # 1
 
 option go_package = "github.com/volumefi/cronchain/x/valset/types";
@@ -15,7 +16,12 @@ service Query {
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
     option (google.api.http).get = "/volumefi/cronchain/valset/params";
   }
-  // this line is used by starport scaffolding # 2
+  // Queries a list of ValidatorInfo items.
+	rpc ValidatorInfo(QueryValidatorInfoRequest) returns (QueryValidatorInfoResponse) {
+		option (google.api.http).get = "/volumefi/cronchain/valset/validator_info/{valAddr}";
+	}
+
+// this line is used by starport scaffolding # 2
 }
 
 // QueryParamsRequest is request type for the Query/Params RPC method.
@@ -25,6 +31,14 @@ message QueryParamsRequest {}
 message QueryParamsResponse {
   // params holds all the parameters of this module.
   Params params = 1 [(gogoproto.nullable) = false];
+}
+
+message QueryValidatorInfoRequest {
+  string valAddr = 1;
+}
+
+message QueryValidatorInfoResponse {
+  Validator validator = 1;
 }
 
 // this line is used by starport scaffolding # 3

--- a/x/valset/client/cli/query.go
+++ b/x/valset/client/cli/query.go
@@ -25,6 +25,8 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 	}
 
 	cmd.AddCommand(CmdQueryParams())
+	cmd.AddCommand(CmdValidatorInfo())
+
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/x/valset/client/cli/query_validator_info.go
+++ b/x/valset/client/cli/query_validator_info.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+	"github.com/volumefi/cronchain/x/valset/types"
+)
+
+var _ = strconv.Itoa(0)
+
+func CmdValidatorInfo() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "validator-info [val-addr]",
+		Short: "Query ValidatorInfo",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			reqValAddr := args[0]
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryValidatorInfoRequest{
+
+				ValAddr: reqValAddr,
+			}
+
+			res, err := queryClient.ValidatorInfo(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/valset/keeper/grpc_query_validator_info.go
+++ b/x/valset/keeper/grpc_query_validator_info.go
@@ -1,0 +1,33 @@
+package keeper
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/volumefi/cronchain/x/valset/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ValidatorInfo returns validator info. It's not related to a snapshot.
+func (k Keeper) ValidatorInfo(goCtx context.Context, req *types.QueryValidatorInfoRequest) (*types.QueryValidatorInfoResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	valAddr, err := sdk.ValAddressFromBech32(req.ValAddr)
+
+	if err != nil {
+		return nil, err
+	}
+
+	val, err := k.getValidator(ctx, valAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.QueryValidatorInfoResponse{
+		Validator: val,
+	}, nil
+}

--- a/x/valset/types/query.pb.go
+++ b/x/valset/types/query.pb.go
@@ -113,35 +113,132 @@ func (m *QueryParamsResponse) GetParams() Params {
 	return Params{}
 }
 
+type QueryValidatorInfoRequest struct {
+	ValAddr string `protobuf:"bytes,1,opt,name=valAddr,proto3" json:"valAddr,omitempty"`
+}
+
+func (m *QueryValidatorInfoRequest) Reset()         { *m = QueryValidatorInfoRequest{} }
+func (m *QueryValidatorInfoRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryValidatorInfoRequest) ProtoMessage()    {}
+func (*QueryValidatorInfoRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_c5cac31ff5c559b6, []int{2}
+}
+func (m *QueryValidatorInfoRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryValidatorInfoRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryValidatorInfoRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryValidatorInfoRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryValidatorInfoRequest.Merge(m, src)
+}
+func (m *QueryValidatorInfoRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryValidatorInfoRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryValidatorInfoRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryValidatorInfoRequest proto.InternalMessageInfo
+
+func (m *QueryValidatorInfoRequest) GetValAddr() string {
+	if m != nil {
+		return m.ValAddr
+	}
+	return ""
+}
+
+type QueryValidatorInfoResponse struct {
+	Validator *Validator `protobuf:"bytes,1,opt,name=validator,proto3" json:"validator,omitempty"`
+}
+
+func (m *QueryValidatorInfoResponse) Reset()         { *m = QueryValidatorInfoResponse{} }
+func (m *QueryValidatorInfoResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryValidatorInfoResponse) ProtoMessage()    {}
+func (*QueryValidatorInfoResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_c5cac31ff5c559b6, []int{3}
+}
+func (m *QueryValidatorInfoResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryValidatorInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryValidatorInfoResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryValidatorInfoResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryValidatorInfoResponse.Merge(m, src)
+}
+func (m *QueryValidatorInfoResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryValidatorInfoResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryValidatorInfoResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryValidatorInfoResponse proto.InternalMessageInfo
+
+func (m *QueryValidatorInfoResponse) GetValidator() *Validator {
+	if m != nil {
+		return m.Validator
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*QueryParamsRequest)(nil), "volumefi.cronchain.valset.QueryParamsRequest")
 	proto.RegisterType((*QueryParamsResponse)(nil), "volumefi.cronchain.valset.QueryParamsResponse")
+	proto.RegisterType((*QueryValidatorInfoRequest)(nil), "volumefi.cronchain.valset.QueryValidatorInfoRequest")
+	proto.RegisterType((*QueryValidatorInfoResponse)(nil), "volumefi.cronchain.valset.QueryValidatorInfoResponse")
 }
 
 func init() { proto.RegisterFile("valset/query.proto", fileDescriptor_c5cac31ff5c559b6) }
 
 var fileDescriptor_c5cac31ff5c559b6 = []byte{
-	// 307 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x90, 0xbd, 0x4e, 0xf3, 0x30,
-	0x14, 0x86, 0xe3, 0x4f, 0x1f, 0x1d, 0xcc, 0xe6, 0x76, 0x80, 0x0a, 0x19, 0x5a, 0x16, 0x40, 0x60,
-	0xab, 0xe5, 0x02, 0x90, 0x3a, 0x30, 0x43, 0x07, 0x06, 0x36, 0x27, 0x32, 0xae, 0xa5, 0xc6, 0xc7,
-	0x8d, 0x9d, 0x8a, 0xae, 0x5c, 0x01, 0x82, 0x95, 0x0b, 0xea, 0x58, 0x89, 0x85, 0x09, 0xa1, 0x84,
-	0x0b, 0x41, 0x8d, 0x53, 0xa4, 0x8a, 0x1f, 0xb1, 0x59, 0xc7, 0xcf, 0xf3, 0xfa, 0xf5, 0xc1, 0x64,
-	0x2a, 0xc6, 0x4e, 0x7a, 0x3e, 0xc9, 0x65, 0x36, 0x63, 0x36, 0x03, 0x0f, 0x64, 0x7b, 0x0a, 0xe3,
-	0x3c, 0x95, 0x37, 0x9a, 0x25, 0x19, 0x98, 0x64, 0x24, 0xb4, 0x61, 0x01, 0x6b, 0xb7, 0x14, 0x28,
-	0xa8, 0x28, 0xbe, 0x3c, 0x05, 0xa1, 0xbd, 0xa3, 0x00, 0xd4, 0x58, 0x72, 0x61, 0x35, 0x17, 0xc6,
-	0x80, 0x17, 0x5e, 0x83, 0x71, 0xf5, 0xed, 0x51, 0x02, 0x2e, 0x05, 0xc7, 0x63, 0xe1, 0x64, 0x78,
-	0x87, 0x4f, 0x7b, 0xb1, 0xf4, 0xa2, 0xc7, 0xad, 0x50, 0xda, 0x54, 0x70, 0xcd, 0x36, 0xeb, 0x3a,
-	0x56, 0x64, 0x22, 0xad, 0x03, 0xba, 0x2d, 0x4c, 0x2e, 0x97, 0xda, 0x45, 0x35, 0x1c, 0xca, 0x49,
-	0x2e, 0x9d, 0xef, 0x5e, 0xe1, 0xe6, 0xda, 0xd4, 0x59, 0x30, 0x4e, 0x92, 0x33, 0xdc, 0x08, 0xf2,
-	0x16, 0xda, 0x43, 0x07, 0x9b, 0xfd, 0x0e, 0xfb, 0xf1, 0x37, 0x2c, 0xa8, 0x83, 0xff, 0xf3, 0xd7,
-	0xdd, 0x68, 0x58, 0x6b, 0xfd, 0x27, 0x84, 0x37, 0xaa, 0x60, 0xf2, 0x80, 0x70, 0x23, 0x20, 0xe4,
-	0xe4, 0x97, 0x94, 0xaf, 0xdd, 0xda, 0xec, 0xaf, 0x78, 0x28, 0xdd, 0x3d, 0xbc, 0x7b, 0x7e, 0x7f,
-	0xfc, 0xb7, 0x4f, 0x3a, 0x7c, 0xe5, 0xf1, 0x4f, 0x8f, 0xaf, 0xad, 0x64, 0x70, 0x3e, 0x2f, 0x28,
-	0x5a, 0x14, 0x14, 0xbd, 0x15, 0x14, 0xdd, 0x97, 0x34, 0x5a, 0x94, 0x34, 0x7a, 0x29, 0x69, 0x74,
-	0x7d, 0xac, 0xb4, 0x1f, 0xe5, 0x31, 0x4b, 0x20, 0xfd, 0x2e, 0xe6, 0x76, 0x15, 0xe4, 0x67, 0x56,
-	0xba, 0xb8, 0x51, 0xed, 0xf6, 0xf4, 0x23, 0x00, 0x00, 0xff, 0xff, 0x00, 0x37, 0x7d, 0x85, 0x01,
-	0x02, 0x00, 0x00,
+	// 421 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x92, 0xb1, 0xae, 0xd3, 0x30,
+	0x14, 0x86, 0x93, 0x2b, 0x28, 0xba, 0x46, 0x2c, 0xbe, 0x17, 0xe9, 0x36, 0x42, 0x81, 0x06, 0x06,
+	0x40, 0x10, 0xab, 0x2d, 0x9d, 0x18, 0x10, 0x1d, 0x90, 0xd8, 0x20, 0x43, 0x07, 0x16, 0x70, 0x52,
+	0x37, 0xb5, 0x94, 0xf8, 0xa4, 0xb1, 0x13, 0x51, 0x21, 0x16, 0x9e, 0x00, 0xc1, 0xd3, 0xf0, 0x06,
+	0x1d, 0x2b, 0xb1, 0x74, 0x42, 0xa8, 0xe5, 0x41, 0x50, 0x6d, 0xa7, 0xa8, 0xa2, 0x14, 0xd8, 0x92,
+	0xe3, 0xff, 0xff, 0xcf, 0xe7, 0x73, 0x8c, 0x70, 0x4d, 0x33, 0xc9, 0x14, 0x99, 0x55, 0xac, 0x9c,
+	0x87, 0x45, 0x09, 0x0a, 0x70, 0xbb, 0x86, 0xac, 0xca, 0xd9, 0x84, 0x87, 0x49, 0x09, 0x22, 0x99,
+	0x52, 0x2e, 0x42, 0x23, 0xf3, 0xce, 0x53, 0x48, 0x41, 0xab, 0xc8, 0xf6, 0xcb, 0x18, 0xbc, 0x1b,
+	0x29, 0x40, 0x9a, 0x31, 0x42, 0x0b, 0x4e, 0xa8, 0x10, 0xa0, 0xa8, 0xe2, 0x20, 0xa4, 0x3d, 0xbd,
+	0x9f, 0x80, 0xcc, 0x41, 0x92, 0x98, 0x4a, 0x66, 0xfa, 0x90, 0xba, 0x1b, 0x33, 0x45, 0xbb, 0xa4,
+	0xa0, 0x29, 0x17, 0x5a, 0x6c, 0xb5, 0x67, 0x16, 0xa7, 0xa0, 0x25, 0xcd, 0x9b, 0x80, 0xeb, 0xb6,
+	0x28, 0x05, 0x2d, 0xe4, 0x14, 0x94, 0x29, 0x07, 0xe7, 0x08, 0xbf, 0xdc, 0xa6, 0xbd, 0xd0, 0xda,
+	0x88, 0xcd, 0x2a, 0x26, 0x55, 0x30, 0x42, 0x67, 0x7b, 0x55, 0x59, 0x80, 0x90, 0x0c, 0x3f, 0x41,
+	0x2d, 0x93, 0x79, 0xe1, 0xde, 0x72, 0xef, 0x5e, 0xed, 0x75, 0xc2, 0x3f, 0x5e, 0x32, 0x34, 0xd6,
+	0xe1, 0xa5, 0xc5, 0xb7, 0x9b, 0x4e, 0x64, 0x6d, 0xc1, 0x00, 0xb5, 0x75, 0xee, 0x88, 0x66, 0x7c,
+	0x4c, 0x15, 0x94, 0xcf, 0xc5, 0x04, 0x6c, 0x53, 0x7c, 0x81, 0xae, 0xd4, 0x34, 0x7b, 0x3a, 0x1e,
+	0x97, 0x3a, 0xfe, 0x34, 0x6a, 0x7e, 0x83, 0x37, 0xc8, 0x3b, 0x64, 0xb3, 0x54, 0x43, 0x74, 0x5a,
+	0x37, 0x07, 0x16, 0xec, 0xce, 0x11, 0xb0, 0x5d, 0x48, 0xf4, 0xcb, 0xd6, 0x5b, 0x9d, 0xa0, 0xcb,
+	0xba, 0x05, 0xfe, 0xe4, 0xa2, 0x96, 0x61, 0xc7, 0x0f, 0x8f, 0xa4, 0xfc, 0x3e, 0x34, 0x2f, 0xfc,
+	0x57, 0xb9, 0xe1, 0x0e, 0xee, 0x7d, 0xf8, 0xfa, 0xe3, 0xf3, 0xc9, 0x6d, 0xdc, 0x21, 0x8d, 0x8f,
+	0xec, 0x7c, 0x64, 0x6f, 0x85, 0xf8, 0x8b, 0x8b, 0xae, 0xed, 0x5d, 0x1e, 0x3f, 0xfa, 0x5b, 0xb3,
+	0x43, 0x23, 0xf6, 0x06, 0xff, 0xe9, 0xb2, 0xa4, 0x8f, 0x35, 0xe9, 0x00, 0xf7, 0x8f, 0x90, 0xee,
+	0x66, 0xf9, 0x9a, 0x8b, 0x09, 0x90, 0x77, 0x76, 0x77, 0xef, 0x87, 0xcf, 0x16, 0x6b, 0xdf, 0x5d,
+	0xae, 0x7d, 0xf7, 0xfb, 0xda, 0x77, 0x3f, 0x6e, 0x7c, 0x67, 0xb9, 0xf1, 0x9d, 0xd5, 0xc6, 0x77,
+	0x5e, 0x3d, 0x48, 0xb9, 0x9a, 0x56, 0x71, 0x98, 0x40, 0x7e, 0x28, 0xf8, 0x6d, 0x13, 0xad, 0xe6,
+	0x05, 0x93, 0x71, 0x4b, 0x3f, 0xd8, 0xfe, 0xcf, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0xf0, 0x75,
+	0x13, 0x6d, 0x03, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -158,6 +255,8 @@ const _ = grpc.SupportPackageIsVersion4
 type QueryClient interface {
 	// Parameters queries the parameters of the module.
 	Params(ctx context.Context, in *QueryParamsRequest, opts ...grpc.CallOption) (*QueryParamsResponse, error)
+	// Queries a list of ValidatorInfo items.
+	ValidatorInfo(ctx context.Context, in *QueryValidatorInfoRequest, opts ...grpc.CallOption) (*QueryValidatorInfoResponse, error)
 }
 
 type queryClient struct {
@@ -177,10 +276,21 @@ func (c *queryClient) Params(ctx context.Context, in *QueryParamsRequest, opts .
 	return out, nil
 }
 
+func (c *queryClient) ValidatorInfo(ctx context.Context, in *QueryValidatorInfoRequest, opts ...grpc.CallOption) (*QueryValidatorInfoResponse, error) {
+	out := new(QueryValidatorInfoResponse)
+	err := c.cc.Invoke(ctx, "/volumefi.cronchain.valset.Query/ValidatorInfo", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 type QueryServer interface {
 	// Parameters queries the parameters of the module.
 	Params(context.Context, *QueryParamsRequest) (*QueryParamsResponse, error)
+	// Queries a list of ValidatorInfo items.
+	ValidatorInfo(context.Context, *QueryValidatorInfoRequest) (*QueryValidatorInfoResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -189,6 +299,9 @@ type UnimplementedQueryServer struct {
 
 func (*UnimplementedQueryServer) Params(ctx context.Context, req *QueryParamsRequest) (*QueryParamsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Params not implemented")
+}
+func (*UnimplementedQueryServer) ValidatorInfo(ctx context.Context, req *QueryValidatorInfoRequest) (*QueryValidatorInfoResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ValidatorInfo not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -213,6 +326,24 @@ func _Query_Params_Handler(srv interface{}, ctx context.Context, dec func(interf
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_ValidatorInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryValidatorInfoRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).ValidatorInfo(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/volumefi.cronchain.valset.Query/ValidatorInfo",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).ValidatorInfo(ctx, req.(*QueryValidatorInfoRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "volumefi.cronchain.valset.Query",
 	HandlerType: (*QueryServer)(nil),
@@ -220,6 +351,10 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Params",
 			Handler:    _Query_Params_Handler,
+		},
+		{
+			MethodName: "ValidatorInfo",
+			Handler:    _Query_ValidatorInfo_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -282,6 +417,71 @@ func (m *QueryParamsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryValidatorInfoRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryValidatorInfoRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryValidatorInfoRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.ValAddr) > 0 {
+		i -= len(m.ValAddr)
+		copy(dAtA[i:], m.ValAddr)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.ValAddr)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryValidatorInfoResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryValidatorInfoResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryValidatorInfoResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Validator != nil {
+		{
+			size, err := m.Validator.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -310,6 +510,32 @@ func (m *QueryParamsResponse) Size() (n int) {
 	_ = l
 	l = m.Params.Size()
 	n += 1 + l + sovQuery(uint64(l))
+	return n
+}
+
+func (m *QueryValidatorInfoRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ValAddr)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryValidatorInfoResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Validator != nil {
+		l = m.Validator.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
 	return n
 }
 
@@ -428,6 +654,174 @@ func (m *QueryParamsResponse) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if err := m.Params.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryValidatorInfoRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryValidatorInfoRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryValidatorInfoRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ValAddr", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ValAddr = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryValidatorInfoResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryValidatorInfoResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryValidatorInfoResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Validator", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Validator == nil {
+				m.Validator = &Validator{}
+			}
+			if err := m.Validator.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/x/valset/types/query.pb.gw.go
+++ b/x/valset/types/query.pb.gw.go
@@ -51,6 +51,60 @@ func local_request_Query_Params_0(ctx context.Context, marshaler runtime.Marshal
 
 }
 
+func request_Query_ValidatorInfo_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryValidatorInfoRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["valAddr"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "valAddr")
+	}
+
+	protoReq.ValAddr, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "valAddr", err)
+	}
+
+	msg, err := client.ValidatorInfo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_ValidatorInfo_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryValidatorInfoRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["valAddr"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "valAddr")
+	}
+
+	protoReq.ValAddr, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "valAddr", err)
+	}
+
+	msg, err := server.ValidatorInfo(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
 // UnaryRPC     :call QueryServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -77,6 +131,29 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_Params_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_ValidatorInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_ValidatorInfo_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_ValidatorInfo_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -141,13 +218,37 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("GET", pattern_Query_ValidatorInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_ValidatorInfo_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_ValidatorInfo_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
 var (
 	pattern_Query_Params_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"volumefi", "cronchain", "valset", "params"}, "", runtime.AssumeColonVerbOpt(true)))
+
+	pattern_Query_ValidatorInfo_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"volumefi", "cronchain", "valset", "validator_info", "valAddr"}, "", runtime.AssumeColonVerbOpt(true)))
 )
 
 var (
 	forward_Query_Params_0 = runtime.ForwardResponseMessage
+
+	forward_Query_ValidatorInfo_0 = runtime.ForwardResponseMessage
 )


### PR DESCRIPTION
## Background

From Sparrow's perspective, we'd want to know the validator info, such as which keys they have registered and their external accounts so that we can register new ones if Sparrow detects it.

## Related to

- #66 
- #71  