### PR TITLE
initial dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+###########################
+####     Base image    ####
+###########################
+FROM golang:1.18-stretch AS base
+MAINTAINER Matija Martinic <matija@volume.finance>
+WORKDIR /app
+
+###########################
+#### Local development ####
+###########################
+FROM base AS local-dev
+ENTRYPOINT ["go", "run", "./cmd/palomad/"]
+
+###########################
+####     Builder       ####
+###########################
+FROM base AS builder
+COPY . /app
+RUN \
+	--mount=type=cache,target=/go/pkg/mod \
+	--mount=type=cache,target=/root/.cache/go-build \
+	cd /app && go build -o /palomad ./cmd/palomad
+
+###########################
+####  Local testnet    ####
+###########################
+FROM ubuntu AS local-testnet
+ENTRYPOINT ["/palomad"]
+COPY --from=builder /palomad /palomad
+ 


### PR DESCRIPTION
# Related Github tickets

- #85 

# Background

An initial dockerfile for paloma. It supports local-dev (which is still in TODO phase),  and local-testnet modes of work.


# Testing completed

- [x] tested this with the compose for running it locally
