### PR TITLE
Query the consensus reached messages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pb.go linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.pb.go linguist-generated=true
+**/*.pb.go linguist-generated=true

--- a/proto/consensus/query.proto
+++ b/proto/consensus/query.proto
@@ -5,6 +5,7 @@ import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "consensus/params.proto";
+import "consensus/consensus_queue.proto";
 import "google/protobuf/any.proto";
 // this line is used by starport scaffolding # 1
 
@@ -53,13 +54,24 @@ message MessageToSign {
   google.protobuf.Any msg = 3;
 }
 
+message MessageApprovedSignData {
+  string valAddress = 1;
+  bytes signature = 2;
+}
+
+message MessageApproved {
+  bytes nonce = 1;
+  uint64 id = 2;
+  google.protobuf.Any msg = 3;
+  repeated MessageApprovedSignData signData = 4;
+}
+
 message QueryConsensusReachedRequest {
   string queueTypeName = 1;
 }
 
 message QueryConsensusReachedResponse {
-  string queueTypeName = 1;
-  repeated MessageToSign messages = 2;
+  repeated MessageApproved messages = 1;
 }
 
 // this line is used by starport scaffolding # 3

--- a/x/consensus/keeper/grpc_query_consensus_reached.go
+++ b/x/consensus/keeper/grpc_query_consensus_reached.go
@@ -23,13 +23,23 @@ func (k Keeper) ConsensusReached(goCtx context.Context, req *types.QueryConsensu
 		return nil, err
 	}
 
-	res := &types.QueryConsensusReachedResponse{
-		QueueTypeName: req.QueueTypeName,
-	}
+	res := &types.QueryConsensusReachedResponse{}
 
 	for _, msg := range msgs {
-		res.Messages = append(res.Messages, queuedMessageToMessageToSign(msg))
+		approvedMessage := &types.MessageApproved{
+			Nonce:    msg.Nonce(),
+			Id:       msg.GetId(),
+			Msg:      msg.GetMsg(),
+			SignData: []*types.MessageApprovedSignData{},
+		}
+		for _, signData := range msg.GetSignData() {
+			approvedMessage.SignData = append(approvedMessage.SignData, &types.MessageApprovedSignData{
+				ValAddress: signData.GetValAddress(),
+				Signature:  signData.GetSignature(),
+			})
+		}
+		res.Messages = append(res.Messages, approvedMessage)
 	}
 
-	return &types.QueryConsensusReachedResponse{}, nil
+	return res, nil
 }

--- a/x/consensus/types/query.pb.go
+++ b/x/consensus/types/query.pb.go
@@ -270,6 +270,126 @@ func (m *MessageToSign) GetMsg() *types.Any {
 	return nil
 }
 
+type MessageApprovedSignData struct {
+	ValAddress string `protobuf:"bytes,1,opt,name=valAddress,proto3" json:"valAddress,omitempty"`
+	Signature  []byte `protobuf:"bytes,2,opt,name=signature,proto3" json:"signature,omitempty"`
+}
+
+func (m *MessageApprovedSignData) Reset()         { *m = MessageApprovedSignData{} }
+func (m *MessageApprovedSignData) String() string { return proto.CompactTextString(m) }
+func (*MessageApprovedSignData) ProtoMessage()    {}
+func (*MessageApprovedSignData) Descriptor() ([]byte, []int) {
+	return fileDescriptor_6f285c5fddf73b75, []int{5}
+}
+func (m *MessageApprovedSignData) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MessageApprovedSignData) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MessageApprovedSignData.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MessageApprovedSignData) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MessageApprovedSignData.Merge(m, src)
+}
+func (m *MessageApprovedSignData) XXX_Size() int {
+	return m.Size()
+}
+func (m *MessageApprovedSignData) XXX_DiscardUnknown() {
+	xxx_messageInfo_MessageApprovedSignData.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MessageApprovedSignData proto.InternalMessageInfo
+
+func (m *MessageApprovedSignData) GetValAddress() string {
+	if m != nil {
+		return m.ValAddress
+	}
+	return ""
+}
+
+func (m *MessageApprovedSignData) GetSignature() []byte {
+	if m != nil {
+		return m.Signature
+	}
+	return nil
+}
+
+type MessageApproved struct {
+	Nonce    []byte                     `protobuf:"bytes,1,opt,name=nonce,proto3" json:"nonce,omitempty"`
+	Id       uint64                     `protobuf:"varint,2,opt,name=id,proto3" json:"id,omitempty"`
+	Msg      *types.Any                 `protobuf:"bytes,3,opt,name=msg,proto3" json:"msg,omitempty"`
+	SignData []*MessageApprovedSignData `protobuf:"bytes,4,rep,name=signData,proto3" json:"signData,omitempty"`
+}
+
+func (m *MessageApproved) Reset()         { *m = MessageApproved{} }
+func (m *MessageApproved) String() string { return proto.CompactTextString(m) }
+func (*MessageApproved) ProtoMessage()    {}
+func (*MessageApproved) Descriptor() ([]byte, []int) {
+	return fileDescriptor_6f285c5fddf73b75, []int{6}
+}
+func (m *MessageApproved) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MessageApproved) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MessageApproved.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MessageApproved) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MessageApproved.Merge(m, src)
+}
+func (m *MessageApproved) XXX_Size() int {
+	return m.Size()
+}
+func (m *MessageApproved) XXX_DiscardUnknown() {
+	xxx_messageInfo_MessageApproved.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MessageApproved proto.InternalMessageInfo
+
+func (m *MessageApproved) GetNonce() []byte {
+	if m != nil {
+		return m.Nonce
+	}
+	return nil
+}
+
+func (m *MessageApproved) GetId() uint64 {
+	if m != nil {
+		return m.Id
+	}
+	return 0
+}
+
+func (m *MessageApproved) GetMsg() *types.Any {
+	if m != nil {
+		return m.Msg
+	}
+	return nil
+}
+
+func (m *MessageApproved) GetSignData() []*MessageApprovedSignData {
+	if m != nil {
+		return m.SignData
+	}
+	return nil
+}
+
 type QueryConsensusReachedRequest struct {
 	QueueTypeName string `protobuf:"bytes,1,opt,name=queueTypeName,proto3" json:"queueTypeName,omitempty"`
 }
@@ -278,7 +398,7 @@ func (m *QueryConsensusReachedRequest) Reset()         { *m = QueryConsensusReac
 func (m *QueryConsensusReachedRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryConsensusReachedRequest) ProtoMessage()    {}
 func (*QueryConsensusReachedRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_6f285c5fddf73b75, []int{5}
+	return fileDescriptor_6f285c5fddf73b75, []int{7}
 }
 func (m *QueryConsensusReachedRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -315,15 +435,14 @@ func (m *QueryConsensusReachedRequest) GetQueueTypeName() string {
 }
 
 type QueryConsensusReachedResponse struct {
-	QueueTypeName string           `protobuf:"bytes,1,opt,name=queueTypeName,proto3" json:"queueTypeName,omitempty"`
-	Messages      []*MessageToSign `protobuf:"bytes,2,rep,name=messages,proto3" json:"messages,omitempty"`
+	Messages []*MessageApproved `protobuf:"bytes,1,rep,name=messages,proto3" json:"messages,omitempty"`
 }
 
 func (m *QueryConsensusReachedResponse) Reset()         { *m = QueryConsensusReachedResponse{} }
 func (m *QueryConsensusReachedResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryConsensusReachedResponse) ProtoMessage()    {}
 func (*QueryConsensusReachedResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_6f285c5fddf73b75, []int{6}
+	return fileDescriptor_6f285c5fddf73b75, []int{8}
 }
 func (m *QueryConsensusReachedResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -352,14 +471,7 @@ func (m *QueryConsensusReachedResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_QueryConsensusReachedResponse proto.InternalMessageInfo
 
-func (m *QueryConsensusReachedResponse) GetQueueTypeName() string {
-	if m != nil {
-		return m.QueueTypeName
-	}
-	return ""
-}
-
-func (m *QueryConsensusReachedResponse) GetMessages() []*MessageToSign {
+func (m *QueryConsensusReachedResponse) GetMessages() []*MessageApproved {
 	if m != nil {
 		return m.Messages
 	}
@@ -372,6 +484,8 @@ func init() {
 	proto.RegisterType((*QueryQueuedMessagesForSigningRequest)(nil), "volumefi.paloma.consensus.QueryQueuedMessagesForSigningRequest")
 	proto.RegisterType((*QueryQueuedMessagesForSigningResponse)(nil), "volumefi.paloma.consensus.QueryQueuedMessagesForSigningResponse")
 	proto.RegisterType((*MessageToSign)(nil), "volumefi.paloma.consensus.MessageToSign")
+	proto.RegisterType((*MessageApprovedSignData)(nil), "volumefi.paloma.consensus.MessageApprovedSignData")
+	proto.RegisterType((*MessageApproved)(nil), "volumefi.paloma.consensus.MessageApproved")
 	proto.RegisterType((*QueryConsensusReachedRequest)(nil), "volumefi.paloma.consensus.QueryConsensusReachedRequest")
 	proto.RegisterType((*QueryConsensusReachedResponse)(nil), "volumefi.paloma.consensus.QueryConsensusReachedResponse")
 }
@@ -379,45 +493,50 @@ func init() {
 func init() { proto.RegisterFile("consensus/query.proto", fileDescriptor_6f285c5fddf73b75) }
 
 var fileDescriptor_6f285c5fddf73b75 = []byte{
-	// 604 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x53, 0x4f, 0x6f, 0xd3, 0x30,
-	0x14, 0x6f, 0xba, 0x3f, 0x02, 0x8f, 0x21, 0x64, 0x0a, 0xca, 0xaa, 0x11, 0xb6, 0x30, 0x50, 0x41,
-	0x22, 0xd6, 0x8a, 0x04, 0x3b, 0x51, 0x3a, 0x26, 0x10, 0x87, 0x4d, 0x2c, 0x4c, 0x1c, 0x90, 0x50,
-	0xe5, 0x26, 0x6e, 0x1a, 0xa9, 0xb1, 0xd3, 0x38, 0x29, 0x54, 0x88, 0x0b, 0x57, 0x2e, 0x08, 0xbe,
-	0xd4, 0x2e, 0xa0, 0x49, 0x5c, 0xb8, 0x80, 0x50, 0xcb, 0x07, 0x41, 0xb1, 0x9d, 0xd2, 0xae, 0x6b,
-	0xbb, 0x71, 0x4b, 0xfc, 0x7e, 0x7f, 0xde, 0xef, 0xf9, 0x19, 0x5c, 0x71, 0x18, 0xe5, 0x84, 0xf2,
-	0x84, 0xa3, 0x76, 0x42, 0xa2, 0xae, 0x15, 0x46, 0x2c, 0x66, 0x70, 0xa5, 0xc3, 0x5a, 0x49, 0x40,
-	0x1a, 0xbe, 0x15, 0xe2, 0x16, 0x0b, 0xb0, 0x35, 0x80, 0x15, 0x0b, 0x1e, 0xf3, 0x98, 0x40, 0xa1,
-	0xf4, 0x4b, 0x12, 0x8a, 0xab, 0x1e, 0x63, 0x5e, 0x8b, 0x20, 0x1c, 0xfa, 0x08, 0x53, 0xca, 0x62,
-	0x1c, 0xfb, 0x8c, 0x72, 0x55, 0xbd, 0xe3, 0x30, 0x1e, 0x30, 0x8e, 0xea, 0x98, 0x13, 0xe9, 0x83,
-	0x3a, 0x9b, 0x75, 0x12, 0xe3, 0x4d, 0x14, 0x62, 0xcf, 0xa7, 0x02, 0xac, 0xb0, 0x57, 0xff, 0x75,
-	0x14, 0xe2, 0x08, 0x07, 0x99, 0xc6, 0x8a, 0x72, 0x10, 0x7f, 0xf5, 0xa4, 0x81, 0x30, 0x55, 0xdd,
-	0x9a, 0x05, 0x00, 0xf7, 0x53, 0xd1, 0xe7, 0x02, 0x6f, 0x93, 0x76, 0x42, 0x78, 0x6c, 0xbe, 0x04,
-	0x97, 0x47, 0x4e, 0x79, 0x98, 0x0a, 0xc3, 0x0a, 0x58, 0x94, 0xba, 0xba, 0xb6, 0xa6, 0x95, 0x96,
-	0xca, 0xeb, 0xd6, 0xc4, 0xac, 0x96, 0xa4, 0x6e, 0xcf, 0x1f, 0xfe, 0xba, 0x9e, 0xb3, 0x15, 0xcd,
-	0x6c, 0x81, 0x0d, 0xa1, 0xbb, 0x9f, 0x90, 0x84, 0xb8, 0xbb, 0x84, 0x73, 0xec, 0x11, 0xfe, 0x84,
-	0x45, 0x2f, 0x7c, 0x8f, 0xfa, 0xd4, 0x53, 0xfe, 0xd0, 0x00, 0xa0, 0x83, 0x5b, 0x55, 0xd7, 0x8d,
-	0x08, 0x97, 0x66, 0xe7, 0xed, 0xa1, 0x13, 0xb8, 0x01, 0x96, 0xdb, 0xa9, 0xc4, 0x41, 0x37, 0x24,
-	0x7b, 0x38, 0x20, 0x7a, 0x5e, 0x40, 0x46, 0x0f, 0xcd, 0x37, 0xe0, 0xe6, 0x0c, 0x37, 0x95, 0x6b,
-	0x0f, 0x2c, 0x07, 0xb2, 0x7a, 0xc0, 0xd2, 0x9a, 0xae, 0xad, 0xcd, 0x95, 0x96, 0xca, 0xa5, 0x29,
-	0xf1, 0x76, 0x87, 0xf1, 0xf6, 0x28, 0xdd, 0x7c, 0x0d, 0x96, 0x47, 0xea, 0xb0, 0x00, 0x16, 0x28,
-	0xa3, 0x0e, 0x11, 0x51, 0x2e, 0xd8, 0xf2, 0x07, 0x5e, 0x04, 0x79, 0xdf, 0x15, 0xad, 0xcf, 0xdb,
-	0x79, 0xdf, 0x85, 0xb7, 0xc0, 0x5c, 0xc0, 0x3d, 0x7d, 0x4e, 0xcc, 0xb6, 0x60, 0xc9, 0x4b, 0xb3,
-	0xb2, 0x4b, 0xb3, 0xaa, 0xb4, 0x6b, 0xa7, 0x00, 0x73, 0x07, 0xac, 0x8a, 0x5c, 0x8f, 0xb3, 0x6e,
-	0x6c, 0x82, 0x9d, 0x26, 0x71, 0xb3, 0xe9, 0x8d, 0x4d, 0x47, 0x3b, 0x69, 0x3a, 0x1f, 0x35, 0x70,
-	0x6d, 0x82, 0x8c, 0x1a, 0xcb, 0xa9, 0x74, 0xe0, 0x0e, 0x38, 0xa7, 0xd2, 0x73, 0x3d, 0x7f, 0xc6,
-	0xb9, 0x0d, 0x98, 0xe5, 0xaf, 0xf3, 0x60, 0x41, 0x74, 0x03, 0x3f, 0x6b, 0x60, 0x51, 0x2e, 0x0f,
-	0xbc, 0x3b, 0x45, 0x68, 0x7c, 0x6b, 0x8b, 0xd6, 0x69, 0xe1, 0x32, 0x9f, 0x79, 0xfb, 0xc3, 0xf7,
-	0x3f, 0x5f, 0xf2, 0x37, 0xe0, 0x3a, 0xca, 0x78, 0x48, 0xf2, 0xd0, 0xf1, 0x77, 0x04, 0x7f, 0x6a,
-	0x40, 0x9f, 0xb4, 0x46, 0xb0, 0x32, 0xcb, 0x77, 0xc6, 0xba, 0x17, 0x1f, 0xfd, 0xbf, 0x80, 0x8a,
-	0xf2, 0x50, 0x44, 0xd9, 0x82, 0xf7, 0xa7, 0x44, 0x11, 0xd7, 0xe6, 0xd6, 0xb2, 0x91, 0xd7, 0x1a,
-	0x2c, 0xaa, 0x71, 0x15, 0xe1, 0x9b, 0x06, 0x2e, 0x1d, 0xdf, 0x03, 0xf8, 0x60, 0x56, 0x5b, 0x13,
-	0x16, 0xb0, 0xb8, 0x75, 0x76, 0xa2, 0xca, 0xf1, 0x54, 0xe4, 0xa8, 0xc2, 0x8a, 0x6a, 0xdf, 0x69,
-	0x62, 0x9f, 0x8e, 0x47, 0x19, 0x7c, 0xd5, 0x22, 0x29, 0x80, 0xde, 0x8d, 0x2c, 0xe5, 0xfb, 0xed,
-	0x67, 0x87, 0x3d, 0x43, 0x3b, 0xea, 0x19, 0xda, 0xef, 0x9e, 0xa1, 0x7d, 0xea, 0x1b, 0xb9, 0xa3,
-	0xbe, 0x91, 0xfb, 0xd1, 0x37, 0x72, 0xaf, 0x90, 0xe7, 0xc7, 0xcd, 0xa4, 0x6e, 0x39, 0x2c, 0x38,
-	0xc9, 0xe4, 0xed, 0x90, 0x4d, 0xdc, 0x0d, 0x09, 0xaf, 0x2f, 0x8a, 0x17, 0x78, 0xef, 0x6f, 0x00,
-	0x00, 0x00, 0xff, 0xff, 0x5f, 0xb0, 0x62, 0x5e, 0xf0, 0x05, 0x00, 0x00,
+	// 675 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x54, 0xcf, 0x4e, 0x13, 0x41,
+	0x18, 0xef, 0x96, 0x42, 0xe0, 0x03, 0xd4, 0x8c, 0x55, 0x4b, 0x83, 0x0b, 0xac, 0x68, 0x90, 0xc4,
+	0x9d, 0x50, 0x13, 0xe5, 0x24, 0x16, 0x09, 0xc6, 0x03, 0x44, 0x56, 0xa2, 0x89, 0x89, 0x69, 0xa6,
+	0xdd, 0x61, 0xd9, 0xa4, 0x3b, 0xb3, 0xec, 0xec, 0x56, 0x1b, 0xe3, 0xc5, 0x27, 0x30, 0xfa, 0x20,
+	0xbe, 0x06, 0x17, 0x0d, 0x89, 0x17, 0x2f, 0x1a, 0x03, 0x3e, 0x88, 0xd9, 0x99, 0x69, 0x4b, 0x0b,
+	0xa5, 0x68, 0xbc, 0xed, 0xce, 0x7c, 0xdf, 0xef, 0xcf, 0xf7, 0x67, 0xe0, 0x4a, 0x8d, 0x33, 0x41,
+	0x99, 0x48, 0x04, 0xde, 0x4b, 0x68, 0xd4, 0xb4, 0xc3, 0x88, 0xc7, 0x1c, 0x4d, 0x35, 0x78, 0x3d,
+	0x09, 0xe8, 0x8e, 0x6f, 0x87, 0xa4, 0xce, 0x03, 0x62, 0xb7, 0xc3, 0x8a, 0x79, 0x8f, 0x7b, 0x5c,
+	0x46, 0xe1, 0xf4, 0x4b, 0x25, 0x14, 0xa7, 0x3d, 0xce, 0xbd, 0x3a, 0xc5, 0x24, 0xf4, 0x31, 0x61,
+	0x8c, 0xc7, 0x24, 0xf6, 0x39, 0x13, 0xfa, 0x76, 0xb1, 0xc6, 0x45, 0xc0, 0x05, 0xae, 0x12, 0x41,
+	0x15, 0x0f, 0x6e, 0x2c, 0x55, 0x69, 0x4c, 0x96, 0x70, 0x48, 0x3c, 0x9f, 0xc9, 0x60, 0x1d, 0x7b,
+	0xb5, 0xa3, 0x28, 0x24, 0x11, 0x09, 0x5a, 0x18, 0x33, 0x9d, 0xf3, 0xf6, 0x57, 0x65, 0x2f, 0xa1,
+	0x09, 0xd5, 0x01, 0x53, 0x5a, 0x82, 0xfc, 0xab, 0x26, 0x3b, 0x98, 0x30, 0x6d, 0xc7, 0xca, 0x03,
+	0xda, 0x4a, 0x59, 0x9f, 0x4a, 0x40, 0x87, 0xee, 0x25, 0x54, 0xc4, 0xd6, 0x73, 0xb8, 0xdc, 0x75,
+	0x2a, 0xc2, 0x14, 0x17, 0xad, 0xc0, 0x88, 0x22, 0x2e, 0x18, 0xb3, 0xc6, 0xc2, 0x78, 0x69, 0xce,
+	0xee, 0x5b, 0x0c, 0x5b, 0xa5, 0xae, 0xe6, 0xf6, 0x7f, 0xce, 0x64, 0x1c, 0x9d, 0x66, 0xd5, 0x61,
+	0x5e, 0xe2, 0x6e, 0xa5, 0xe2, 0xdc, 0x0d, 0x2a, 0x04, 0xf1, 0xa8, 0x58, 0xe7, 0xd1, 0x33, 0xdf,
+	0x63, 0x3e, 0xf3, 0x34, 0x3f, 0x32, 0x01, 0x1a, 0xa4, 0x5e, 0x76, 0xdd, 0x88, 0x0a, 0x45, 0x36,
+	0xe6, 0x1c, 0x3b, 0x41, 0xf3, 0x30, 0x29, 0xfd, 0x6d, 0x37, 0x43, 0xba, 0x49, 0x02, 0x5a, 0xc8,
+	0xca, 0x90, 0xee, 0x43, 0xeb, 0x35, 0xdc, 0x1c, 0xc0, 0xa6, 0x7d, 0x6d, 0xc2, 0x64, 0xa0, 0x6e,
+	0xb7, 0x79, 0x7a, 0x57, 0x30, 0x66, 0x87, 0x16, 0xc6, 0x4b, 0x0b, 0x67, 0xd8, 0xdb, 0x38, 0x1e,
+	0xef, 0x74, 0xa7, 0x5b, 0xaf, 0x60, 0xb2, 0xeb, 0x1e, 0xe5, 0x61, 0x98, 0x71, 0x56, 0xa3, 0xd2,
+	0xca, 0x84, 0xa3, 0x7e, 0xd0, 0x05, 0xc8, 0xfa, 0xae, 0x94, 0x9e, 0x73, 0xb2, 0xbe, 0x8b, 0x6e,
+	0xc1, 0x50, 0x20, 0xbc, 0xc2, 0x90, 0xac, 0x6d, 0xde, 0x56, 0x4d, 0xb3, 0x5b, 0x4d, 0xb3, 0xcb,
+	0xac, 0xe9, 0xa4, 0x01, 0xd6, 0x0b, 0xb8, 0xa6, 0xe1, 0xcb, 0x61, 0x18, 0xf1, 0x06, 0x75, 0x53,
+	0x92, 0x35, 0x12, 0x93, 0x81, 0x85, 0x9b, 0x86, 0x31, 0xe1, 0x7b, 0x8c, 0xc4, 0x49, 0xa4, 0x8a,
+	0x36, 0xe1, 0x74, 0x0e, 0xac, 0xcf, 0x06, 0x5c, 0xec, 0x41, 0xfe, 0xbf, 0xd2, 0xd1, 0x26, 0x8c,
+	0x0a, 0xad, 0xb5, 0x90, 0x93, 0x45, 0x2e, 0x0d, 0x2e, 0x72, 0xaf, 0x4b, 0xa7, 0x8d, 0x61, 0xad,
+	0xc1, 0xb4, 0x6c, 0xf1, 0xa3, 0x56, 0x8e, 0x43, 0x49, 0x6d, 0x97, 0xba, 0xad, 0x41, 0x3a, 0x31,
+	0x28, 0xc6, 0x69, 0x83, 0xe2, 0xc1, 0xf5, 0x3e, 0x28, 0x7a, 0x40, 0xd6, 0x61, 0x54, 0x77, 0x58,
+	0xe8, 0xd9, 0x58, 0x3c, 0xbf, 0x6c, 0xa7, 0x9d, 0x5b, 0xfa, 0x92, 0x83, 0x61, 0xc9, 0x84, 0x3e,
+	0x1a, 0x30, 0xa2, 0x56, 0x04, 0xdd, 0x39, 0x03, 0xea, 0xe4, 0x6e, 0x16, 0xed, 0xf3, 0x86, 0x2b,
+	0xed, 0xd6, 0xed, 0xf7, 0xdf, 0x7e, 0x7f, 0xca, 0xde, 0x40, 0x73, 0xb8, 0x95, 0x87, 0x55, 0x1e,
+	0xee, 0x7d, 0x4e, 0xd0, 0x0f, 0x03, 0x0a, 0xfd, 0x96, 0x05, 0xad, 0x0c, 0xe2, 0x1d, 0xb0, 0xd4,
+	0xc5, 0x87, 0xff, 0x0e, 0xa0, 0xad, 0x3c, 0x90, 0x56, 0x96, 0xd1, 0xbd, 0x33, 0xac, 0xc8, 0xce,
+	0xba, 0x95, 0x56, 0xc9, 0x2b, 0x3b, 0x3c, 0xaa, 0x08, 0x6d, 0xe1, 0xab, 0x01, 0x97, 0x7a, 0x7b,
+	0x8c, 0xee, 0x0f, 0x92, 0xd5, 0x67, 0xb6, 0x8a, 0xcb, 0x7f, 0x9f, 0xa8, 0x7d, 0x3c, 0x96, 0x3e,
+	0xca, 0x68, 0x45, 0xcb, 0xaf, 0xed, 0x12, 0x9f, 0x9d, 0xb4, 0xd2, 0x79, 0xcc, 0x23, 0x05, 0x80,
+	0xdf, 0x76, 0xcd, 0xed, 0xbb, 0xd5, 0x27, 0xfb, 0x87, 0xa6, 0x71, 0x70, 0x68, 0x1a, 0xbf, 0x0e,
+	0x4d, 0xe3, 0xc3, 0x91, 0x99, 0x39, 0x38, 0x32, 0x33, 0xdf, 0x8f, 0xcc, 0xcc, 0x4b, 0xec, 0xf9,
+	0xf1, 0x6e, 0x52, 0xb5, 0x6b, 0x3c, 0x38, 0x8d, 0xe4, 0xcd, 0x31, 0x9a, 0xb8, 0x19, 0x52, 0x51,
+	0x1d, 0x91, 0xcb, 0x7a, 0xf7, 0x4f, 0x00, 0x00, 0x00, 0xff, 0xff, 0x02, 0xd3, 0x9e, 0x3c, 0xf7,
+	0x06, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -755,6 +874,104 @@ func (m *MessageToSign) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *MessageApprovedSignData) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MessageApprovedSignData) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MessageApprovedSignData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Signature) > 0 {
+		i -= len(m.Signature)
+		copy(dAtA[i:], m.Signature)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.Signature)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ValAddress) > 0 {
+		i -= len(m.ValAddress)
+		copy(dAtA[i:], m.ValAddress)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.ValAddress)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MessageApproved) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MessageApproved) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MessageApproved) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.SignData) > 0 {
+		for iNdEx := len(m.SignData) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.SignData[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintQuery(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if m.Msg != nil {
+		{
+			size, err := m.Msg.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Id != 0 {
+		i = encodeVarintQuery(dAtA, i, uint64(m.Id))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Nonce) > 0 {
+		i -= len(m.Nonce)
+		copy(dAtA[i:], m.Nonce)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.Nonce)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *QueryConsensusReachedRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -816,15 +1033,8 @@ func (m *QueryConsensusReachedResponse) MarshalToSizedBuffer(dAtA []byte) (int, 
 				i = encodeVarintQuery(dAtA, i, uint64(size))
 			}
 			i--
-			dAtA[i] = 0x12
+			dAtA[i] = 0xa
 		}
-	}
-	if len(m.QueueTypeName) > 0 {
-		i -= len(m.QueueTypeName)
-		copy(dAtA[i:], m.QueueTypeName)
-		i = encodeVarintQuery(dAtA, i, uint64(len(m.QueueTypeName)))
-		i--
-		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -912,6 +1122,49 @@ func (m *MessageToSign) Size() (n int) {
 	return n
 }
 
+func (m *MessageApprovedSignData) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ValAddress)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	l = len(m.Signature)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *MessageApproved) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Nonce)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	if m.Id != 0 {
+		n += 1 + sovQuery(uint64(m.Id))
+	}
+	if m.Msg != nil {
+		l = m.Msg.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	if len(m.SignData) > 0 {
+		for _, e := range m.SignData {
+			l = e.Size()
+			n += 1 + l + sovQuery(uint64(l))
+		}
+	}
+	return n
+}
+
 func (m *QueryConsensusReachedRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -931,10 +1184,6 @@ func (m *QueryConsensusReachedResponse) Size() (n int) {
 	}
 	var l int
 	_ = l
-	l = len(m.QueueTypeName)
-	if l > 0 {
-		n += 1 + l + sovQuery(uint64(l))
-	}
 	if len(m.Messages) > 0 {
 		for _, e := range m.Messages {
 			l = e.Size()
@@ -1420,6 +1669,295 @@ func (m *MessageToSign) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *MessageApprovedSignData) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MessageApprovedSignData: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MessageApprovedSignData: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ValAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ValAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Signature", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Signature = append(m.Signature[:0], dAtA[iNdEx:postIndex]...)
+			if m.Signature == nil {
+				m.Signature = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MessageApproved) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MessageApproved: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MessageApproved: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Nonce", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Nonce = append(m.Nonce[:0], dAtA[iNdEx:postIndex]...)
+			if m.Nonce == nil {
+				m.Nonce = []byte{}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			m.Id = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Id |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Msg", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Msg == nil {
+				m.Msg = &types.Any{}
+			}
+			if err := m.Msg.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SignData", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SignData = append(m.SignData, &MessageApprovedSignData{})
+			if err := m.SignData[len(m.SignData)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *QueryConsensusReachedRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1533,38 +2071,6 @@ func (m *QueryConsensusReachedResponse) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field QueueTypeName", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowQuery
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthQuery
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return ErrInvalidLengthQuery
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.QueueTypeName = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 2:
-			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Messages", wireType)
 			}
 			var msglen int
@@ -1592,7 +2098,7 @@ func (m *QueryConsensusReachedResponse) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Messages = append(m.Messages, &MessageToSign{})
+			m.Messages = append(m.Messages, &MessageApproved{})
 			if err := m.Messages[len(m.Messages)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}


### PR DESCRIPTION
# Related Github tickets

- #83 

# Background

Given that the query endpoint for getting messages was made a while ago, it was made as a "placeholder". This PR creates new types to support this endpoint's requirements. It needs to send the message and validators that have signed it. 

# Testing completed

- [x] this was already covered with tests. Adding the new "look" it, doesn't change any behaviour.
