### PR TITLE
Redesign consensus queuer

### DIFF
--- a/x/consensus/keeper/concensus_keeper.go
+++ b/x/consensus/keeper/concensus_keeper.go
@@ -10,7 +10,7 @@ import (
 
 // TODO: add private type for queueTypeName
 
-func AddConcencusQueueType[T ConsensusMsg](k *Keeper, queueTypeName string) {
+func (k Keeper) AddConcencusQueueType(queueTypeName string, typ any) {
 	if k.queueRegistry == nil {
 		k.queueRegistry = make(map[string]consensusQueuer)
 	}
@@ -19,11 +19,12 @@ func AddConcencusQueueType[T ConsensusMsg](k *Keeper, queueTypeName string) {
 		panic("concencus queue already registered")
 	}
 
-	k.queueRegistry[queueTypeName] = consensusQueue[T]{
+	k.queueRegistry[queueTypeName] = consensusQueue{
 		queueTypeName: queueTypeName,
-		sg:            *k,
+		sg:            k,
 		ider:          k.ider,
 		cdc:           k.cdc,
+		typeCheck:     StaticTypeChecker(typ),
 	}
 }
 

--- a/x/consensus/keeper/concensus_keeper_test.go
+++ b/x/consensus/keeper/concensus_keeper_test.go
@@ -28,7 +28,7 @@ func TestEndToEndTestingOfPuttingAndGettingMessagesOfTheConsensusQueue(t *testin
 		require.ErrorIs(t, err, ErrConsensusQueueNotImplemented)
 	})
 
-	AddConcencusQueueType[*testdata.SimpleMessage](keeper, "simple-message")
+	keeper.AddConcencusQueueType("simple-message", &testdata.SimpleMessage{})
 
 	t.Run("it returns no messages for signing", func(t *testing.T) {
 		msgs, err := keeper.GetMessagesForSigning(
@@ -302,7 +302,7 @@ func TestAddingSignatures(t *testing.T) {
 
 	types.ModuleCdc.InterfaceRegistry().RegisterImplementations((*sdk.Msg)(nil), &testdata.SimpleMessage{})
 
-	AddConcencusQueueType[*testdata.SimpleMessage](keeper, "simple-message")
+	keeper.AddConcencusQueueType("simple-message", &testdata.SimpleMessage{})
 
 	err := keeper.PutMessageForSigning(ctx, "simple-message", &testdata.SimpleMessage{
 		Sender: "bob",

--- a/x/consensus/keeper/concensus_queue_test.go
+++ b/x/consensus/keeper/concensus_queue_test.go
@@ -33,11 +33,12 @@ func TestConsensusQueueAllMethods(t *testing.T) {
 	types.RegisterInterfaces(registry)
 
 	sg := keeperutil.SimpleStoreGetter(stateStore.GetKVStore(storeKey))
-	cq := consensusQueue[*testtypes.SimpleMessage]{
+	cq := consensusQueue{
 		queueTypeName: "simple-message",
 		sg:            sg,
 		ider:          keeperutil.NewIDGenerator(sg, nil),
 		cdc:           types.ModuleCdc,
+		typeCheck:     StaticTypeChecker(&testtypes.SimpleMessage{}),
 	}
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, nil)
 

--- a/x/consensus/keeper/errors.go
+++ b/x/consensus/keeper/errors.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	ErrIncorrectMessageType           = whoops.Errorf("underlying message type does not match: should be %T, but provided type is %T")
+	ErrIncorrectMessageType           = whoops.Errorf("underlying message type does not match: %T")
 	ErrUnableToSaveMessageWithoutID   = whoops.String("unable to save message without an ID")
 	ErrConsensusQueueNotImplemented   = whoops.Errorf("consensus queue not implemented for queueTypeName %s")
 	ErrMessageDoesNotExist            = whoops.Errorf("message id %d does not exist")

--- a/x/consensus/keeper/keeper.go
+++ b/x/consensus/keeper/keeper.go
@@ -51,16 +51,15 @@ func NewKeeper(
 			portKeeper,
 			scopedKeeper,
 		),
-		cdc:        cdc,
-		storeKey:   storeKey,
-		memKey:     memKey,
-		paramstore: ps,
-		valset:     valsetKeeper,
+		cdc:           cdc,
+		storeKey:      storeKey,
+		memKey:        memKey,
+		paramstore:    ps,
+		valset:        valsetKeeper,
+		queueRegistry: make(map[string]consensusQueuer),
 	}
 	ider := keeperutil.NewIDGenerator(k, nil)
 	k.ider = ider
-
-	AddConcencusQueueType[*types.SignSmartContractExecute](k, "sign-smart-contract-execute-messages")
 
 	return k
 }


### PR DESCRIPTION
# Related Github tickets

- https://github.com/palomachain/paloma/issues/105

# Background

Given that initial design used generics, it doesn't play well with the idea of using the attestation module. Given that attestation module is much more important than using generics, I am dropping them here in favour of easier API to use and making it easier for attestation module to come to life.

# Testing completed

- [ ] made sure that all existing tests are working and changed code to ensure that those still pass
