### PR TITLE
Use custom type for consensus-queue-type

### DIFF
--- a/x/consensus/keeper/concensus_queue.go
+++ b/x/consensus/keeper/concensus_queue.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"fmt"
 	"reflect"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -162,5 +163,5 @@ func (c consensusQueue) signingQueueKey() string {
 	if c.queueTypeName == "" {
 		panic("queueTypeName can't be empty")
 	}
-	return consensusQueueSigningKey + c.queueTypeName
+	return fmt.Sprintf("%s-%s", consensusQueueSigningKey, string(c.queueTypeName))
 }

--- a/x/consensus/keeper/concensus_queue.go
+++ b/x/consensus/keeper/concensus_queue.go
@@ -27,7 +27,7 @@ type (
 
 	// consensusQueue is a database storing messages that need to be signed.
 	consensusQueue struct {
-		queueTypeName string
+		queueTypeName types.ConsensusQueueType
 		sg            keeperutil.StoreGetter
 		ider          keeperutil.IDGenerator
 		cdc           codecMarshaler

--- a/x/consensus/keeper/concensus_queue_test.go
+++ b/x/consensus/keeper/concensus_queue_test.go
@@ -34,7 +34,7 @@ func TestConsensusQueueAllMethods(t *testing.T) {
 
 	sg := keeperutil.SimpleStoreGetter(stateStore.GetKVStore(storeKey))
 	cq := consensusQueue{
-		queueTypeName: "simple-message",
+		queueTypeName: types.ConsensusQueueType("simple-message"),
 		sg:            sg,
 		ider:          keeperutil.NewIDGenerator(sg, nil),
 		cdc:           types.ModuleCdc,

--- a/x/consensus/keeper/grpc_query_consensus_reached.go
+++ b/x/consensus/keeper/grpc_query_consensus_reached.go
@@ -17,7 +17,7 @@ func (k Keeper) ConsensusReached(goCtx context.Context, req *types.QueryConsensu
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	msgs, err := k.GetMessagesThatHaveReachedConsensus(ctx, req.QueueTypeName)
+	msgs, err := k.GetMessagesThatHaveReachedConsensus(ctx, types.ConsensusQueueType(req.QueueTypeName))
 
 	if err != nil {
 		return nil, err

--- a/x/consensus/keeper/keeper.go
+++ b/x/consensus/keeper/keeper.go
@@ -22,7 +22,7 @@ type (
 		paramstore paramtypes.Subspace
 
 		ider          keeperutil.IDGenerator
-		queueRegistry map[string]consensusQueuer
+		queueRegistry map[types.ConsensusQueueType]consensusQueuer
 
 		valset types.ValsetKeeper
 	}

--- a/x/consensus/keeper/keeper.go
+++ b/x/consensus/keeper/keeper.go
@@ -56,7 +56,7 @@ func NewKeeper(
 		memKey:        memKey,
 		paramstore:    ps,
 		valset:        valsetKeeper,
-		queueRegistry: make(map[string]consensusQueuer),
+		queueRegistry: make(map[types.ConsensusQueueType]consensusQueuer),
 	}
 	ider := keeperutil.NewIDGenerator(k, nil)
 	k.ider = ider

--- a/x/consensus/keeper/query_queued_messages_for_signing.go
+++ b/x/consensus/keeper/query_queued_messages_for_signing.go
@@ -15,7 +15,7 @@ func (k Keeper) QueuedMessagesForSigning(goCtx context.Context, req *types.Query
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	msgs, err := k.GetMessagesForSigning(ctx, req.QueueTypeName, sdk.ValAddress(req.ValAddress))
+	msgs, err := k.GetMessagesForSigning(ctx, types.ConsensusQueueType(req.QueueTypeName), sdk.ValAddress(req.ValAddress))
 	if err != nil {
 		return nil, err
 	}

--- a/x/consensus/types/consensus.go
+++ b/x/consensus/types/consensus.go
@@ -6,6 +6,8 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 )
 
+type ConsensusQueueType string
+
 //go:generate mockery --name=QueuedSignedMessageI
 type QueuedSignedMessageI interface {
 	proto.Message


### PR DESCRIPTION
# Related Github tickets

- #105 

# Background

Want to bring a bit more security by ensuring that only custom type can be used for the queue name. This is more for hardening it in the future, as right now it doesn't really add much value.

# Testing completed

- [ ] made sure that existing tests are working and changed code to ensure that those still pass
