### PR TITLE
Fix setup-chain-validator failing if gsed is not installed.

### DIFF
--- a/scripts/setup-chain-validator.sh
+++ b/scripts/setup-chain-validator.sh
@@ -2,7 +2,11 @@
 
 set -ex
 
-which gsed > /dev/null
+if which gsed > /dev/null; then
+  SED="$(which gsed)"
+else
+  SED="$(which sed)"
+fi
 
 if [ "$?" != "0" ]; then
   SED=$(which sed)


### PR DESCRIPTION
# Related Github tickets

- None

# Background

Currently the script fails immediately when gsed is not installed. Fix this.

# Testing completed

- [x] Manual testing.
