### PR TITLE
Allow balances query in testnet setup to be run from anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ You can run `palomad keys list` on their respective nodes. On the main node run:
 
 ```shell
 palomad --fees 200grain tx bank send -y "$ORIGINAL_VALIDATOR_ADDRESS" "$VALIDATOR_ADDRESS" 100000000grain
-# Verify that we see the funds:
-palomad query bank balances "$VALIDATOR_ADDRESS"
+```
+
+We can then verify that the funds have been deposited:
+```shell
+palomad query bank balances --node tcp://157.245.76.119:26657 "$VALIDATOR_ADDRESS"
 ```
 
 Stake your funds and create our validator.


### PR DESCRIPTION
Fixes https://github.com/palomachain/paloma/issues/203

# Background

Previously this query could only be run from a node already in the network. Now it should be runnable from anywhere.

# Testing completed

- [x] The new query runs on nodes not running the network.
