### PR TITLE
Use address for ecrecover

### DIFF
--- a/x/consensus/keeper/concensus_keeper.go
+++ b/x/consensus/keeper/concensus_keeper.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"fmt"
-
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/palomachain/paloma/x/consensus/keeper/consensus"
@@ -46,9 +44,6 @@ func (k Keeper) addConcencusQueueType(cq consensus.Queuer) {
 // getConsensusQueue gets the consensus queue for the given type.
 func (k Keeper) getConsensusQueue(queueTypeName string) (consensus.Queuer, error) {
 	cq, ok := k.queueRegistry[queueTypeName]
-	for i := range k.queueRegistry {
-		fmt.Println("AAAAAAA", i)
-	}
 	if !ok {
 		return nil, ErrConsensusQueueNotImplemented.Format(queueTypeName)
 	}

--- a/x/evm/keeper/keeper_integration_test.go
+++ b/x/evm/keeper/keeper_integration_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"crypto/ecdsa"
 	"math/big"
 	"strings"
 	"testing"
@@ -89,15 +88,14 @@ func TestEndToEndForEvmArbitraryCall(t *testing.T) {
 
 	private, err := crypto.GenerateKey()
 	require.NoError(t, err)
-	pkBz := crypto.FromECDSAPub(private.Public().(*ecdsa.PublicKey))
 
-	accAddr := rand.ETHAddress()
+	accAddr := crypto.PubkeyToAddress(private.PublicKey)
 	err = a.ValsetKeeper.AddExternalChainInfo(ctx, validators[0].GetOperator(), []*valsettypes.ExternalChainInfo{
 		{
 			ChainType: chainType,
 			ChainID:   chainID,
 			Address:   accAddr.Hex(),
-			Pubkey:    pkBz,
+			Pubkey:    accAddr[:],
 		},
 	})
 


### PR DESCRIPTION
# Related Github tickets

- #197 

# Background

Public keys are not really neccecary in the EVM world and to verify a signature, an address can be used. Thus using address for verifying EVM signatures.

# Testing completed

- [x] ensured that existing tests are working
