### PR TITLE
Add pprof for paloma

### DIFF
--- a/cmd/palomad/main.go
+++ b/cmd/palomad/main.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"fmt"
 	"os"
+
+	"net/http"
+	"net/http/pprof"
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 	"github.com/palomachain/paloma/app"
+	"github.com/spf13/cobra"
 	"github.com/tendermint/starport/starport/pkg/cosmoscmd"
 )
 
@@ -16,6 +21,32 @@ func main() {
 		app.Name,
 		app.ModuleBasics,
 		app.New,
+		cosmoscmd.CustomizeStartCmd(func(cmd *cobra.Command) {
+			oldPreRunE := cmd.PreRunE
+			cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+				go func() {
+					listen := os.Getenv("PPROF_LISTEN")
+					if len(listen) > 0 {
+						fmt.Println("enabling PPROF")
+						mux := http.NewServeMux()
+
+						mux.HandleFunc("/debug/pprof/", pprof.Index)
+						mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+						mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+						mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+						mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+						if err := http.ListenAndServe(listen, mux); err != nil {
+							panic(err)
+						}
+					}
+				}()
+				if oldPreRunE != nil {
+					return oldPreRunE(cmd, args)
+				}
+				return nil
+			}
+		}),
 		// this line is used by starport scaffolding # root/arguments
 	)
 	if err := svrcmd.Execute(rootCmd, app.DefaultNodeHome); err != nil {


### PR DESCRIPTION
# Related Github tickets

- #209 

# Background

We have a memory leak.
zz

# Testing completed

- [x] started pprof and verified that it works
  - `PPROF_LISTEN=localhost:7777 go run ./cmd/palomad start`
  - `go tool pprof -inuse_space http://localhost:7777/debug/pprof/heap\?seconds\=10`
