### PR TITLE
Set max_validators to 125 by default

### DIFF
--- a/scripts/setup-volume-testnet.sh
+++ b/scripts/setup-volume-testnet.sh
@@ -30,6 +30,7 @@ sed -i 's/^keyring-backend = ".*"/keyring-backend = "test"/' client.toml
 sed -i 's/^minimum-gas-prices = ".*"/minimum-gas-prices = "0.001ugrain"/' app.toml
 sed -i 's/^laddr = ".*:26657"/laddr = "tcp:\/\/0.0.0.0:26657"/' config.toml
 jq-i ".chain_id = \"${CHAIN_ID}\"" genesis.json
+jq-i '.app_state.staking.params.max_validators = 125' genesis.json
 jq-i 'walk(if type == "string" and .. == "stake" then "grain" else . end)' genesis.json
 popd
 


### PR DESCRIPTION
https://github.com/palomachain/paloma/pull/268

# Background

Normal default is 100, we would like more people to be able to be validators on the testnet.

# Testing completed

- [x] manual review
