### PR TITLE
Increase max_validators to 125

### DIFF
--- a/app/modules.go
+++ b/app/modules.go
@@ -71,6 +71,7 @@ type StakingModule struct {
 func (StakingModule) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	params := stakingtypes.DefaultParams()
 	params.BondDenom = BondDenom
+	params.MaxValidators = 125
 
 	return cdc.MustMarshalJSON(&stakingtypes.GenesisState{
 		Params: params,


### PR DESCRIPTION
https://github.com/palomachain/paloma/issues/268

# Background

Normal default is 100, we would like more people to be able to be validators on the testnet.

# Testing completed

- [x] manual review
