### PR TITLE
Remove s/stake/ugrain lines from setup scripts

### DIFF
--- a/scripts/setup-chain-validator.sh
+++ b/scripts/setup-chain-validator.sh
@@ -33,7 +33,6 @@ $SED -i 's/keyring-backend = ".*"/keyring-backend = "test"/' client.toml
 $SED -i 's/minimum-gas-prices = ".*"/minimum-gas-prices = "0.001ugrain"/' app.toml
 $SED -i 's/laddr = ".*:26657"/laddr = "tcp:\/\/0.0.0.0:26657"/' config.toml
 jq ".chain_id = \"${CHAIN_ID}\"" genesis.json > temp.json && mv temp.json genesis.json
-jq 'walk(if type == "string" and .. == "stake" then "grain" else . end)' genesis.json > temp.json && mv temp.json genesis.json
 popd
 
 if [[ -z "${ACCOUNT_MNEMONIC:-}" ]]; then

--- a/scripts/setup-volume-testnet.sh
+++ b/scripts/setup-volume-testnet.sh
@@ -30,7 +30,6 @@ sed -i 's/^keyring-backend = ".*"/keyring-backend = "test"/' client.toml
 sed -i 's/^minimum-gas-prices = ".*"/minimum-gas-prices = "0.001ugrain"/' app.toml
 sed -i 's/^laddr = ".*:26657"/laddr = "tcp:\/\/0.0.0.0:26657"/' config.toml
 jq-i ".chain_id = \"${CHAIN_ID}\"" genesis.json
-jq-i 'walk(if type == "string" and .. == "stake" then "grain" else . end)' genesis.json
 popd
 
 name="chase"


### PR DESCRIPTION
https://github.com/palomachain/paloma/issues/267

# Background

This edit is done in DefaultGenesis now

# Testing completed

Initialized a new testnet and:
```
> grep stake .paloma/config/genesis.json
> grep ugrain .paloma/config/genesis.json
              "denom": "ugrain",
          "base": "ugrain",
        "denom": "ugrain",
            "denom": "ugrain",
        "mint_denom": "ugrain",
        "bond_denom": "ugrain"
```
