### PR TITLE
Increase max validators to 175

### DIFF
--- a/app/modules.go
+++ b/app/modules.go
@@ -71,7 +71,7 @@ type StakingModule struct {
 func (StakingModule) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	params := stakingtypes.DefaultParams()
 	params.BondDenom = BondDenom
-	params.MaxValidators = 125
+	params.MaxValidators = 175
 
 	return cdc.MustMarshalJSON(&stakingtypes.GenesisState{
 		Params: params,


### PR DESCRIPTION
https://github.com/palomachain/paloma/issues/300

## Background

This mirrors the value used in Cosmos

## Testing completed

- [x] existing go tests
