### PR TITLE
Move the addrbook and genesis get after unsafe-reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,17 @@ If you're upgrading to the most recent version, you will need to stop `palomad` 
 
 **If you're upgrading from v0.3.0 to v0.4.0 do the following:**
 
+1. Stop paloma 0.3.0 and get 0.4.0
 ```
 service palomad stop 
 wget -O - https://github.com/palomachain/paloma/releases/download/v0.4.0-alpha/paloma_0.4.0-alpha_Linux_x86_64.tar.gz | tar -C /usr/local/bin -xvzf - palomad
-wget -O ~/.paloma/config/genesis.json https://raw.githubusercontent.com/palomachain/testnet/master/paloma-testnet-6/genesis.json
-wget -O ~/.paloma/config/addrbook.json https://raw.githubusercontent.com/palomachain/testnet/master/paloma-testnet-6/addrbook.json
+```
 
-#delete the old database
+2. Delete the old database and get the snapshot genesis and the updated addrbook. Start paloma 0.4.0
+```
 palomad tendermint unsafe-reset-all --home $HOME/.paloma
+wget -O ~/.paloma/config/addrbook.json https://raw.githubusercontent.com/palomachain/testnet/master/paloma-testnet-6/addrbook.json
+wget -O ~/.paloma/config/genesis.json https://raw.githubusercontent.com/palomachain/testnet/master/paloma-testnet-6/genesis.json
 service palomad start
 ```
 


### PR DESCRIPTION
# Background
Looks like we need to arrange the download of the addrbook AND the genesis AFTER unsafe-reset otherwise, the current flow won't work.

# Testing completed
Just updating the ordering of the README instructions.