### PR TITLE
Add breaking change section to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,3 +10,8 @@ _A short paragraph on test what exactly this PR solves._
 
 - [ ] _a list of actions that you've performed to ensure that this PR works as intended_
 - [ ] _99% of the times you should have an item: "wrote tests"_
+
+# Breaking changes
+
+- [ ] I have checked my code for breaking changes
+- [ ] If there are breaking changes, there is a supporting migration.


### PR DESCRIPTION
# Background

There have been a few instances where I have thought or forgotten about code not being backwards compatible, which basically caused the testnet to halt. This is not super important for the testnet, but it's important for the mainnet, thus creating a reminder.

# Testing completed

- [x] irrelevant
