### PR TITLE
Fix the way validator's power percentage was calculated

### DIFF
--- a/x/valset/keeper/keeper.go
+++ b/x/valset/keeper/keeper.go
@@ -248,8 +248,8 @@ func (k Keeper) isNewSnapshotWorthy(currentSnapshot, newSnapshot *types.Snapshot
 	// could own 60% of the network. And all other validators stayed the
 	// (relatively) same.
 	for i := 0; i < len(sortedCurrent); i++ {
-		percentageCurrent := currentSnapshot.TotalShares.ToDec().QuoInt(sortedCurrent[i].ShareCount)
-		percentageNow := newSnapshot.TotalShares.ToDec().QuoInt(sortedNew[i].ShareCount)
+		percentageCurrent := sortedCurrent[i].ShareCount.ToDec().QuoInt(currentSnapshot.TotalShares)
+		percentageNow := sortedNew[i].ShareCount.ToDec().QuoInt(newSnapshot.TotalShares)
 
 		if percentageCurrent.Sub(percentageNow).Abs().MustFloat64() >= 0.01 {
 			return true

--- a/x/valset/keeper/keeper_test.go
+++ b/x/valset/keeper/keeper_test.go
@@ -411,6 +411,38 @@ func TestIsNewSnapshotWorthy(t *testing.T) {
 				},
 			},
 		},
+		{
+			expRes: false,
+			name:   "if the powers are still the same then it's not worthy",
+			curr: &types.Snapshot{
+				TotalShares: sdk.NewInt(100),
+				Validators: []types.Validator{
+					{Address: sdk.ValAddress("123"), ShareCount: sdk.NewInt(20)},
+				},
+			},
+			neww: &types.Snapshot{
+				TotalShares: sdk.NewInt(100),
+				Validators: []types.Validator{
+					{Address: sdk.ValAddress("123"), ShareCount: sdk.NewInt(20)},
+				},
+			},
+		},
+		{
+			expRes: false,
+			name:   "if the powers have change for less than 1%, then it's not worthy",
+			curr: &types.Snapshot{
+				TotalShares: sdk.NewInt(1000),
+				Validators: []types.Validator{
+					{Address: sdk.ValAddress("123"), ShareCount: sdk.NewInt(20)},
+				},
+			},
+			neww: &types.Snapshot{
+				TotalShares: sdk.NewInt(1000),
+				Validators: []types.Validator{
+					{Address: sdk.ValAddress("123"), ShareCount: sdk.NewInt(21)},
+				},
+			},
+		},
 	}
 
 	for _, tt := range testcases {


### PR DESCRIPTION
# Related Github tickets

- https://github.com/palomachain/paloma/issues/373

# Background

Fixes incorrect way of calculating the validator's power percentage. Even though there was a test that was aimed to this trigger this, the numbers still worked though. The valset will trigger only when there was a change of 1% made. Given that `something big / something small` is always greater than `1%` (it's actually always going to be `>= 1`), then this always returned true as `something larger than 1 is always >= 1% (0.01)`. 

# Testing completed

- [x] wrote test
