### PR TITLE
Remove version from filename when building the release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,7 @@ archives:
       windows: Windows
       386: i386
       amd64: x86_64
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE
       - README.md


### PR DESCRIPTION
# Background

Taken from: https://goreleaser.com/customization/archive/.
That way version is only written in the release URL which is generate by the github, so that we don't need to write it two times. Also it works with the latest release.

# Testing completed

- [ ] none
