### PR TITLE
Update instructions for paloma 0.6.1 install

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ N/A
 To get the latest `palomad` binary:
 
 ```shell
-wget -O - https://github.com/palomachain/paloma/releases/download/v0.5.0/paloma_Linux_x86_64.tar.gz | \
+wget -O - https://github.com/palomachain/paloma/releases/download/v0.6.1/paloma_Linux_x86_64.tar.gz  | \
   sudo tar -C /usr/local/bin -xvzf - palomad
 sudo chmod +x /usr/local/bin/palomad
 # Required until we figure out cgo
@@ -53,20 +53,17 @@ sudo wget -P /usr/lib https://github.com/CosmWasm/wasmvm/raw/main/api/libwasmvm.
 
 If you're upgrading to the most recent version, you will need to stop `palomad` before copying the new binary into place.
 
-**If you're upgrading from an older version to v0.5.0 do the following:**
+**If you're upgrading from an older version to v0.6.1 do the following:**
 
-1. Stop your paloma version and get 0.5.0
+1. Stop your paloma version and get 0.6.1
 ```
 service palomad stop
-wget -O - https://github.com/palomachain/paloma/releases/download/v0.5.0/paloma_Linux_x86_64.tar.gz | \
+wget -O - https://github.com/palomachain/paloma/releases/download/v0.6.1/paloma_Linux_x86_64.tar.gz | \
   tar -C /usr/local/bin -xvzf - palomad
 ```
 
-2. Delete the old database and get the snapshot genesis and the updated addrbook. Start paloma 0.5.0
+2. Replace palomad 0.5.0 with latest binary and start paloma 0.6.1
 ```
-palomad tendermint unsafe-reset-all --home $HOME/.paloma
-wget -O ~/.paloma/config/addrbook.json https://raw.githubusercontent.com/palomachain/testnet/master/paloma-testnet-6/addrbook.json
-wget -O ~/.paloma/config/genesis.json https://raw.githubusercontent.com/palomachain/testnet/master/paloma-testnet-6/genesis.json
 service palomad start
 ```
 


### PR DESCRIPTION
# Related Github tickets

1. Update the README for update to palomad version 0.6.1

# Background

Updated README instructions for the community to install and update to the latest version of paloma 0.6.1

# Testing completed
No testing completed. Instructions are simply to install

# Breaking changes
Removed the old genesis update instructions.