### PR TITLE
Fix for incorrect upgrade name

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -367,6 +367,14 @@ func New(
 		},
 	)
 
+	// TODO: this is bug. Upgrade names should be as vMAJOR.MINOR like above.
+	upgradeK.SetUpgradeHandler(
+		semverVersion,
+		func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
+		},
+	)
+
 	app.UpgradeKeeper = upgradeK
 
 	// register the staking hooks


### PR DESCRIPTION
# Background

Upgrade name was supposed to be v0.6 while it has been v0.6.1


# Testing completed

- [x] network can start

# Breaking changes

None