### PR TITLE
Pigeon healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ RestartSec=5
 WorkingDirectory=~
 ExecStartPre=
 ExecStart=/usr/local/bin/palomad start
+Environment=PIGEON_LISTEN_PORT=5757
 ExecReload=
 
 [Install]

--- a/app/pigeon.go
+++ b/app/pigeon.go
@@ -35,7 +35,7 @@ func onceFunc[V any](fn func() V) func() V {
 
 var PigeonHTTPClient = onceFunc(func() *http.Client {
 	return &http.Client{
-		Timeout: time.Second * 30,
+		Timeout: time.Second * 5,
 		Transport: &http.Transport{
 			Dial: (&net.Dialer{
 				Timeout: 5 * time.Second,
@@ -68,7 +68,7 @@ func GetPigonListenPort() int {
 func CheckPigeonRunningLooper(ctx context.Context, client httpClienter) {
 	PigeonMustRun(ctx, client)
 
-	t := time.NewTimer(5 * time.Second)
+	t := time.NewTicker(5 * time.Second)
 	for range t.C {
 		if err := ctx.Err(); err != nil {
 			return
@@ -95,11 +95,11 @@ func PigeonMustRun(ctx context.Context, client httpClienter) {
 
 	var hc pigeonHealthCheck
 	if err := json.NewDecoder(res.Body).Decode(&hc); err != nil {
-		log.Fatal("error encoding pigeon's response: %v", err)
+		log.Fatalf("error encoding pigeon's response: %v", err)
 	}
 
 	if err := checkPid(hc.Pid); err != nil {
-		log.Fatal("error verifying the pid: %v", err)
+		log.Fatalf("error verifying the pid: %v", err)
 	}
 }
 

--- a/app/pigeon.go
+++ b/app/pigeon.go
@@ -1,0 +1,118 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	PigeonListenPortENVName = "PIGEON_LISTEN_PORT"
+)
+
+type pigeonHealthCheck struct {
+	Pid int `json:"pid"`
+}
+
+func onceFunc[V any](fn func() V) func() V {
+	var once sync.Once
+	var val V
+	once.Do(func() {
+		val = fn()
+	})
+	return func() V {
+		return val
+	}
+}
+
+var PigeonHTTPClient = onceFunc(func() *http.Client {
+	return &http.Client{
+		Timeout: time.Second * 30,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: 5 * time.Second,
+			}).Dial,
+			TLSHandshakeTimeout: 5 * time.Second,
+		},
+	}
+})
+
+type httpClienter interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+func GetPigonListenPort() int {
+	listenPort, ok := os.LookupEnv(PigeonListenPortENVName)
+
+	if !ok || listenPort == "" {
+		log.Fatal("pigeon listen port environment variable is not set")
+	}
+
+	port, err := strconv.ParseInt(listenPort, 10, 64)
+
+	if err != nil {
+		log.Fatalf("pigeon's port %s is invalid: %v", listenPort, err)
+	}
+
+	return int(port)
+}
+
+func CheckPigeonRunningLooper(ctx context.Context, client httpClienter) {
+	PigeonMustRun(ctx, client)
+
+	t := time.NewTimer(5 * time.Second)
+	for range t.C {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		PigeonMustRun(ctx, client)
+	}
+}
+
+func PigeonMustRun(ctx context.Context, client httpClienter) {
+
+	port := GetPigonListenPort()
+	// extract port from url and verify that it's open locally
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://127.0.0.1:%d", port), nil)
+	if err != nil {
+		log.Fatalf("couldn't create an HTTP request: %v", err)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("error communicating with pigeon: %v. Is your pigeon running?", err)
+	}
+
+	defer res.Body.Close()
+
+	var hc pigeonHealthCheck
+	if err := json.NewDecoder(res.Body).Decode(&hc); err != nil {
+		log.Fatal("error encoding pigeon's response: %v", err)
+	}
+
+	if err := checkPid(hc.Pid); err != nil {
+		log.Fatal("error verifying the pid: %v", err)
+	}
+}
+
+// checkPid checks if the pid is actually running on this machine.
+// this is not the best check, but it's good enough.
+func checkPid(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+
+	if err := process.Signal(syscall.Signal(0)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/tendermint/tendermint v0.34.19
 	github.com/tendermint/tm-db v0.6.7
 	github.com/vizualni/whoops v0.6.0
+	golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57
 	google.golang.org/genproto v0.0.0-20220728213248-dd149ef739b9
 	google.golang.org/grpc v1.48.0
 	google.golang.org/protobuf v1.28.1
@@ -123,7 +124,6 @@ require (
 	github.com/zondax/hid v0.9.0 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
-	golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57 // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
 	golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect


### PR DESCRIPTION
# Background

We want to stop folks from running paloma chain without them running pigeons. If paloma detects that pigeon is not running, it will kill itself thus stopping a _pigeonless_ validator from entering the valset.

# Testing completed

- [ ] manually tested with both paloma and pigeon

# Breaking changes

Nope. It does not change anything in the state.
