### PR TITLE
Fix an issue jailing inactive validators

### DIFF
--- a/x/valset/keeper/keep_alive.go
+++ b/x/valset/keeper/keep_alive.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	keeperutil "github.com/palomachain/paloma/util/keeper"
 	"github.com/palomachain/paloma/x/valset/types"
 	"github.com/vizualni/whoops"
 )
@@ -85,11 +84,10 @@ func (k Keeper) CanAcceptValidator(ctx sdk.Context, valAddr sdk.ValAddress) erro
 }
 
 func (k Keeper) JailInactiveValidators(ctx sdk.Context) error {
-	store := k.keepAliveStore(ctx)
-	keys, _, _ := keeperutil.IterAllRaw(store, k.cdc)
+	store := k.validatorStore(ctx)
 	var g whoops.Group
-	for _, bz := range keys {
-		valAddr := sdk.ValAddress(bz)
+	for _, val := range k.unjailedValidators(ctx) {
+		valAddr := val.GetOperator()
 		alive, err := k.IsValidatorAlive(ctx, valAddr)
 		if err != nil {
 			g.Add(err)
@@ -104,7 +102,6 @@ func (k Keeper) JailInactiveValidators(ctx sdk.Context) error {
 				k.Jail(ctx, valAddr, types.JailReasonPigeonInactive),
 			)
 		}
-
 	}
 	return g.Return()
 }

--- a/x/valset/keeper/keep_alive_test.go
+++ b/x/valset/keeper/keep_alive_test.go
@@ -23,11 +23,9 @@ func TestJailingInactiveValidators(t *testing.T) {
 		vali.On("IsJailed").Return(false)
 		vali.On("IsBonded").Return(true)
 		vali.On("GetOperator").Return(val)
+		vali.On("GetStatus").Return(stakingtypes.Bonded)
 		consAddr := sdk.ConsAddress(val)
 		if toBeJailed {
-			err := k.KeepValidatorAlive(ctx.WithBlockTime(time.Unix(1000, 0)), val)
-			require.NoError(t, err)
-
 			vali.On("GetConsAddr").Return(consAddr, nil)
 			ms.StakingKeeper.On("Jail", mock.Anything, consAddr)
 		} else {

--- a/x/valset/keeper/keep_alive_test.go
+++ b/x/valset/keeper/keep_alive_test.go
@@ -22,6 +22,7 @@ func TestJailingInactiveValidators(t *testing.T) {
 		ms.StakingKeeper.On("Validator", mock.Anything, val).Return(vali)
 		vali.On("IsJailed").Return(false)
 		vali.On("IsBonded").Return(true)
+		vali.On("GetOperator").Return(val)
 		consAddr := sdk.ConsAddress(val)
 		if toBeJailed {
 			err := k.KeepValidatorAlive(ctx.WithBlockTime(time.Unix(1000, 0)), val)

--- a/x/valset/keeper/keeper.go
+++ b/x/valset/keeper/keeper.go
@@ -290,6 +290,18 @@ func (k Keeper) isNewSnapshotWorthy(currentSnapshot, newSnapshot *types.Snapshot
 	return false
 }
 
+func (k Keeper) unjailedValidators(ctx sdk.Context) []stakingtypes.ValidatorI {
+	validators := []stakingtypes.ValidatorI{}
+	k.staking.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) bool {
+		if !val.IsJailed() {
+			validators = append(validators, val)
+		}
+		return false
+	})
+
+	return validators
+}
+
 // createNewSnapshot builds a current snapshot of validators.
 func (k Keeper) createNewSnapshot(ctx sdk.Context) (*types.Snapshot, error) {
 	validators := []stakingtypes.ValidatorI{}


### PR DESCRIPTION
# Related Github tickets

- #406 

# Background

We were iterating on list of all "good and honest" validators to see who is behaving badly, while we should have iterated over the list of all the validators

# Testing completed

- [x] wrote tests

# Breaking changes
Yep!
- [x] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
