### PR TITLE
Delete old valset updates

### DIFF
--- a/x/evm/types/expected_keepers.go
+++ b/x/evm/types/expected_keepers.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/palomachain/paloma/x/consensus/keeper/consensus"
+	consensustypes "github.com/palomachain/paloma/x/consensus/types"
 	valsettypes "github.com/palomachain/paloma/x/valset/types"
 )
 
@@ -25,6 +26,8 @@ type BankKeeper interface {
 type ConsensusKeeper interface {
 	PutMessageInQueue(ctx sdk.Context, queueTypeName string, msg consensus.ConsensusMsg, opts *consensus.PutOptions) error
 	RemoveConsensusQueue(ctx sdk.Context, queueTypeName string) error
+	GetMessagesFromQueue(ctx sdk.Context, queueTypeName string, n int) (msgs []consensustypes.QueuedSignedMessageI, err error)
+	DeleteJob(ctx sdk.Context, queueTypeName string, id uint64) (err error)
 }
 
 //go:generate mockery --name=ValsetKeeper

--- a/x/evm/types/mocks/ConsensusKeeper.go
+++ b/x/evm/types/mocks/ConsensusKeeper.go
@@ -16,6 +16,43 @@ type ConsensusKeeper struct {
 	mock.Mock
 }
 
+// DeleteJob provides a mock function with given fields: ctx, queueTypeName, id
+func (_m *ConsensusKeeper) DeleteJob(ctx types.Context, queueTypeName string, id uint64) error {
+	ret := _m.Called(ctx, queueTypeName, id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(types.Context, string, uint64) error); ok {
+		r0 = rf(ctx, queueTypeName, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// GetMessagesFromQueue provides a mock function with given fields: ctx, queueTypeName, n
+func (_m *ConsensusKeeper) GetMessagesFromQueue(ctx types.Context, queueTypeName string, n int) ([]consensustypes.QueuedSignedMessageI, error) {
+	ret := _m.Called(ctx, queueTypeName, n)
+
+	var r0 []consensustypes.QueuedSignedMessageI
+	if rf, ok := ret.Get(0).(func(types.Context, string, int) []consensustypes.QueuedSignedMessageI); ok {
+		r0 = rf(ctx, queueTypeName, n)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]consensustypes.QueuedSignedMessageI)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(types.Context, string, int) error); ok {
+		r1 = rf(ctx, queueTypeName, n)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // PutMessageInQueue provides a mock function with given fields: ctx, queueTypeName, msg, opts
 func (_m *ConsensusKeeper) PutMessageInQueue(ctx types.Context, queueTypeName string, msg consensustypes.ConsensusMsg, opts *consensus.PutOptions) error {
 	ret := _m.Called(ctx, queueTypeName, msg, opts)


### PR DESCRIPTION
# Related Github tickets

- https://github.com/palomachain/paloma/issues/440

# Background

If the target chain is halted, then paloma will continue generating update valsets. Then queue of messages will start to fill up. Those messages then will need to leave from the queue to a target chain. Once they do then they do it in (somewhat) orderly style, thus valsets which are no longer true will still be deployed. This PR will clear the queue.

# Testing completed

- [x] wrote tests

# Breaking changes
Yep!
- [x] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
