### PR TITLE
Update readme to match the new minimum for eth-main

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ wget -O ~/.paloma/config/addrbook.json https://raw.githubusercontent.com/palomac
 service palomad start
 ```
 
-7. If you are planning to be a **VALIDATOR with stake**, ensure that your pigeon relayer is up & running and that you have at least 0.1 ETH on eth mainnet target chain address that is in your pigeon configuration file.
+7. If you are planning to be a **VALIDATOR with stake**, ensure that your pigeon relayer is up & running and that you have at least 0.05 ETH on eth mainnet target chain address that is in your pigeon configuration file.
 
 ### Connecting to an existing testnet.
 


### PR DESCRIPTION
Genesis for paloma-testnet-9
<img width="810" alt="Screenshot 2022-08-26 at 09 01 10" src="https://user-images.githubusercontent.com/454988/186842302-451fa123-f8cf-498a-860e-91b9998ff99d.png">


```json
        {
          "blockHashAtHeight": "0x872b621cdfd03de6c8d19e82ddfb524f9946242178903f8d6f2c540e7425ffb6",
          "blockHeight": "15351127",
          "chainID": "1",
          "chainReferenceID": "eth-main",
          "minOnChainBalance": "50000000000000000"
        }
```

-------


https://eth-converter.com/


<img width="940" alt="Screenshot 2022-08-26 at 09 02 34" src="https://user-images.githubusercontent.com/454988/186842539-f05708c2-8dec-47ad-a635-82a9e6841256.png">







