### PR TITLE
Incorrect argument types when calling a compass-evm logic call function

### DIFF
--- a/x/evm/keeper/errors.go
+++ b/x/evm/keeper/errors.go
@@ -10,4 +10,6 @@ const (
 	ErrConsensusNotAchieved                        = whoops.String("evm: consensus not achieved")
 	ErrCannotAddSupportForChainThatExists          = whoops.Errorf("chain info already exists: %s")
 	ErrCannotActiveSmartContractThatIsNotDeploying = whoops.String("trying to activate a smart contract that is not currently deploying")
+
+	ErrWasmExecuteMessageNotValid = whoops.String("message is not valid")
 )

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -811,7 +810,7 @@ var _ = Describe("wasm message handler", func() {
 	Context("invalid message", func() {
 		When("message is empty", func() {
 			It("returns an error", func() {
-				Expect(subject()).To(MatchError(wasmtypes.ErrUnknownMsg))
+				Expect(subject()).To(MatchError(keeper.ErrWasmExecuteMessageNotValid))
 			})
 		})
 	})


### PR DESCRIPTION
# Related Github tickets

- https://github.com/palomachain/paloma/issues/476

# Background

See https://github.com/palomachain/paloma/issues/476
# Testing completed

- [x] tested this e2e manually by inserting the job to the queue

# Breaking changes
Not a breaking change.

- [x] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
