### PR TITLE
Disable adding a new EVM chain if one with the chain id already exists

### DIFF
--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -470,6 +470,17 @@ func (k Keeper) AddSupportForNewChain(
 	default:
 		return whoops.Wrap(ErrUnexpectedError, err)
 	}
+	all, err := k.GetAllChainInfos(ctx)
+	if err != nil {
+		return err
+	}
+	for _, existing := range all {
+		if existing.GetChainID() == chainID {
+			return ErrCannotAddSupportForChainThatExists.Format(chainReferenceID).
+				WrapS("chain with chainID %d already exists", chainID)
+		}
+	}
+
 	chainInfo := &types.ChainInfo{
 		ChainID:              chainID,
 		ChainReferenceID:     chainReferenceID,

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -225,6 +225,18 @@ func TestAddingSupportForNewChain(t *testing.T) {
 		require.Equal(t, newChain.GetChainReferenceID(), gotChainInfo.GetChainReferenceID())
 		require.Equal(t, newChain.GetBlockHashAtHeight(), gotChainInfo.GetReferenceBlockHash())
 		require.Equal(t, newChain.GetBlockHeight(), gotChainInfo.GetReferenceBlockHeight())
+		t.Run("it returns an error if we try to add a chian whose chainID already exists", func(t *testing.T) {
+			newChain.ChainReferenceID = "something_new"
+			err := a.EvmKeeper.AddSupportForNewChain(
+				ctx,
+				newChain.GetChainReferenceID(),
+				newChain.GetChainID(),
+				newChain.GetBlockHeight(),
+				newChain.GetBlockHashAtHeight(),
+				big.NewInt(55),
+			)
+			require.ErrorIs(t, err, keeper.ErrCannotAddSupportForChainThatExists)
+		})
 	})
 
 	t.Run("when chainReferenceID already exists then it returns an error", func(t *testing.T) {
@@ -350,6 +362,7 @@ var _ = Describe("evm", func() {
 				Description:       "bla",
 				BlockHeight:       uint64(456),
 				BlockHashAtHeight: "0x1234",
+				ChainID:           1,
 			}
 			chain2 := &types.AddChainProposal{
 				ChainReferenceID:  "chain2",
@@ -357,6 +370,7 @@ var _ = Describe("evm", func() {
 				Description:       "bla",
 				BlockHeight:       uint64(123),
 				BlockHashAtHeight: "0x5678",
+				ChainID:           2,
 			}
 			BeforeEach(func() {
 				validators = genValidators(25, 25000)

--- a/x/paloma/keeper/keeper_integration_test.go
+++ b/x/paloma/keeper/keeper_integration_test.go
@@ -82,7 +82,7 @@ var _ = Describe("jailing validators with missing external chain infos", func() 
 		BeforeEach(func() {
 			err := a.EvmKeeper.AddSupportForNewChain(ctx, "c1", 1, 123, "abc", big.NewInt(555))
 			Expect(err).To(BeNil())
-			err = a.EvmKeeper.AddSupportForNewChain(ctx, "c2", 1, 123, "abc", big.NewInt(555))
+			err = a.EvmKeeper.AddSupportForNewChain(ctx, "c2", 2, 123, "abc", big.NewInt(555))
 			Expect(err).To(BeNil())
 		})
 


### PR DESCRIPTION
# Related Github tickets

- a list of github issues that are relevant for this PR

# Background

Disable adding a new EVM chain if one with the chain id already exists

# Testing completed

- [x] wrote tests

# Breaking changes
This is a breaking change.

- [x] I have checked my code for breaking changes
