### PR TITLE
Disable paloma if the version is different than what the government said should be

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -427,7 +427,9 @@ func New(
 		keys[palomamoduletypes.StoreKey],
 		keys[palomamoduletypes.MemStoreKey],
 		app.GetSubspace(palomamoduletypes.ModuleName),
+		semverVersion,
 		app.ValsetKeeper,
+		app.UpgradeKeeper,
 	)
 
 	app.PalomaKeeper.ExternalChains = []palomamoduletypes.ExternalChainSupporterKeeper{

--- a/app/app_setup.go
+++ b/app/app_setup.go
@@ -26,7 +26,7 @@ func NewTestApp(t testing, isCheckTx bool) TestApp {
 	encCfg := cosmoscmd.MakeEncodingConfig(ModuleBasics)
 
 	oldVersion := version.Version
-	version.Version = "v0.0.1"
+	version.Version = "v5.1.6"
 	t.Cleanup(func() {
 		version.Version = oldVersion
 	})

--- a/testutil/keeper/paloma.go
+++ b/testutil/keeper/paloma.go
@@ -42,7 +42,9 @@ func PalomaKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 		storeKey,
 		memStoreKey,
 		paramsSubspace,
+		"v0.0.1", // do not use this PalomaKeeper function!
 		valsetkeeper.Keeper{},
+		nil,
 	)
 
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())

--- a/x/paloma/keeper/keeper.go
+++ b/x/paloma/keeper/keeper.go
@@ -146,6 +146,7 @@ func (k Keeper) CheckChainVersion(ctx sdk.Context) {
 		return
 	case -1: // appVersion < govVer
 		// not good :(
+		abandon()
 		return
 	}
 }

--- a/x/paloma/keeper/keeper.go
+++ b/x/paloma/keeper/keeper.go
@@ -146,8 +146,6 @@ func (k Keeper) CheckChainVersion(ctx sdk.Context) {
 		return
 	case -1: // appVersion < govVer
 		// not good :(
-		panic("OH NO")
-		abandon()
 		return
 	}
 }

--- a/x/paloma/module.go
+++ b/x/paloma/module.go
@@ -167,7 +167,9 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
-func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
+func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
+	am.keeper.CheckChainVersion(ctx)
+}
 
 // EndBlock executes all ABCI EndBlock logic respective to the capability module. It
 // returns no validator updates.

--- a/x/paloma/types/expected_keepers.go
+++ b/x/paloma/types/expected_keepers.go
@@ -31,3 +31,7 @@ type ValsetKeeper interface {
 type ExternalChainSupporterKeeper interface {
 	xchain.Info
 }
+
+type UpgradeKeeper interface {
+	GetLastCompletedUpgrade(ctx sdk.Context) (string, int64)
+}


### PR DESCRIPTION

# Background

Disable paloma if the version is different than what the government said should be
# Testing completed

- [x] wrote tests

# Breaking changes
Not a breaking change.

- [x] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
