### PR TITLE
Upgrade wasmd to v0.29.0-rc2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/palomachain/paloma
 go 1.18
 
 require (
-	github.com/CosmWasm/wasmd v0.29.0-rc1
+	github.com/CosmWasm/wasmd v0.29.0-rc2
 	github.com/CosmWasm/wasmvm v1.1.1
 	github.com/cosmos/cosmos-sdk v0.45.8
 	github.com/cosmos/ibc-go/v3 v3.3.0

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/wasmd v0.29.0-rc1 h1:5lvbzKkstmYFVBv1NomQqUAkun7iz6M4sE3AUBHC9Iw=
-github.com/CosmWasm/wasmd v0.29.0-rc1/go.mod h1:eRrfjYNj8/PhyA2wdIuHeR/Czjy9/1UGuIr0NJocleA=
+github.com/CosmWasm/wasmd v0.29.0-rc2 h1:fVDze+hS7S+eUsmeAOiqQjolKZ2q2byrnbsIk0Anl4k=
+github.com/CosmWasm/wasmd v0.29.0-rc2/go.mod h1:eRrfjYNj8/PhyA2wdIuHeR/Czjy9/1UGuIr0NJocleA=
 github.com/CosmWasm/wasmvm v1.1.1 h1:0xtdrmmsP9fibe+x42WcMkp5aQ738BICgcH3FNVLzm4=
 github.com/CosmWasm/wasmvm v1.1.1/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx0FCXc+A=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=


### PR DESCRIPTION
# Related Github tickets

- https://github.com/palomachain/paloma/issues/517

# Background

Fixing the ignite's default migration version in the wasmd.

# Testing completed

- [ ] none

# Breaking changes

- [ ] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
