### PR TITLE
chore: release infra

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,26 @@
+queue_rules:
+  - name: default
+    conditions:
+      - "#approved-reviews-by>1"
+
+pull_request_rules:
+  - name: "Auto-merge to master branch with label 'A:automerge' and branch protection passing"
+    conditions:
+      - "#approved-reviews-by>1"
+      - base=master
+      - label=A:automerge
+    actions:
+      queue:
+        name: default
+        method: squash
+        commit_message_template: |
+          {{ title }} (#{{ number }})
+          {{ body }}
+  - name: Backport patches to v0.11.x branch
+    conditions:
+      - base=master
+      - label=backport/0.11.x
+    actions:
+      backport:
+        branches:
+          - release/v0.11.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+<!--
+Guiding Principles:
+
+Changelogs are for humans, not machines.
+There should be an entry for every single version.
+The same types of changes should be grouped.
+Versions and sections should be linkable.
+The latest version comes first.
+The release date of each version is displayed.
+Mention whether you follow Semantic Versioning.
+
+Usage:
+
+Change log entries are to be added to the Unreleased section under the
+appropriate stanza (see below). Each entry should ideally include a tag and
+the Github issue reference in the following format:
+
+* (<tag>) [#<PR-number](<link-to-PR>) <message>
+
+Types of changes (Stanzas):
+
+"Features" for new features.
+"Improvements" for changes in existing functionality.
+"Deprecated" for soon-to-be removed features.
+"Bug Fixes" for any bug fixes.
+"Client Breaking" for breaking Protobuf, gRPC and REST routes used by end-users.
+"CLI Breaking" for breaking CLI commands.
+"API Breaking" for breaking exported APIs used by developers building on SDK.
+"State Machine Breaking" for any changes that result in a different AppState given same genesisState and txList.
+Ref: https://keepachangelog.com/en/1.0.0/
+-->
+
+# Changelog
+
+## [Unreleased]


### PR DESCRIPTION
## Changelog

- Added CHANGELOG
  - Note, there are no entries currently.
  - Incoming changes from PRs (after this PR) must ensure to add relevant changelog entries under the `Unreleased` section.
  - When a release is made, the release notes are populated from this changelog in the release branch.
 - Created `release/v0.11.x` branch
   - This is where changes from `master` will be backported to
   - This release branch also contains the release notes
- Created backport label for `release/v0.11.x`
- Added mergify config for backporting and auto-merging

**NOTE** for repo/org admin:

- Ensure setup branch protection rules for release branches using `release/v*`.
- Ensure branch protection rules for `master` are up to date and correct
- Allow auto-merge (https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository)

closes: #628