### PR TITLE
makefile: fix version handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ HTTPS_GIT      := https://github.com/palomachain/paloma.git
 ###############################################################################
 
 ifeq (,$(VERSION))
-  VERSION := $(shell git describe --exact-match 2>/dev/null)
+  VERSION := $(shell git describe --exact-match --tags 2>/dev/null | sed 's/^v//')
   # if VERSION is empty, then populate it with branch's name and raw commit hash
   ifeq (,$(VERSION))
     VERSION := $(BRANCH)-$(COMMIT)


### PR DESCRIPTION
After building the code out of the v0.11.6, the palomad's version command's output is ostensibly malformed:

[alessio@fedora paloma]$ palomad version
HEAD-6a6c9280f76e0c5a510d80aebcfef4e94b7043c0

The git describe command used in the makefile needs both the --tags option and correct version number handling in order to print out correctly the version number inferred by a tagged commit.

Closes: #668

# Testing completed

- [ ] _a list of actions that you've performed to ensure that this PR works as intended_
- [ ] _99% of the times you should have an item: "wrote tests"_

# Breaking changes

- [ ] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
