### PR TITLE
use special non-master branch as dependabot target

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,4 @@ updates:
     labels:
       - "A:automerge"
       - "T:dependencies"
+    target-branch: dependabot-updates


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/6

# Background

We want to use non-master branch for dependabot PRs target

# Testing completed

- [ ] no changes made in the code so no testing

# Breaking changes

- [ ] I have checked my code for breaking changes
