### PR TITLE
ignore cosmos in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,5 @@ updates:
     labels:
       - "A:automerge"
       - "T:dependencies"
+    ignore:
+      - dependency-name: "github.com/cosmos/cosmos-sdk"


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/6

# Background

Cosmos SDK updates are backward incompatible, we want to update it manually
