### PR TITLE
add genesis commands

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -156,7 +156,7 @@ var (
 	// and genesis verification.
 	ModuleBasics = module.NewBasicManager(
 		auth.AppModuleBasic{},
-		genutil.AppModuleBasic{},
+		genutil.NewAppModuleBasic(genutiltypes.DefaultMessageValidator),
 		BankModule{},
 		capability.AppModuleBasic{},
 		StakingModule{},

--- a/cmd/palomad/root.go
+++ b/cmd/palomad/root.go
@@ -151,7 +151,7 @@ func rootPreRunE(cmd *cobra.Command, args []string) error {
 func initRootCmd(rootCmd *cobra.Command, ac appCreator) {
 	rootCmd.AddCommand(
 		genutilcli.InitCmd(ac.moduleManager, palomaapp.DefaultNodeHome),
-		AddGenesisAccountCmd(palomaapp.DefaultNodeHome),
+		genesisCommand(ac.encCfg),
 		tmcli.NewCompletionCmd(rootCmd, true),
 		debug.Cmd(),
 		config.Cmd(),
@@ -166,6 +166,16 @@ func initRootCmd(rootCmd *cobra.Command, ac appCreator) {
 		txCommand(ac.moduleManager),
 		keys.Commands(palomaapp.DefaultNodeHome),
 	)
+}
+
+// genesisCommand builds genesis-related `palomad genesis` command. Users may provide application specific commands as a parameter
+func genesisCommand(encodingConfig params.EncodingConfig, cmds ...*cobra.Command) *cobra.Command {
+	cmd := genutilcli.GenesisCoreCommand(encodingConfig.TxConfig, palomaapp.ModuleBasics, palomaapp.DefaultNodeHome)
+
+	for _, sub_cmd := range cmds {
+		cmd.AddCommand(sub_cmd)
+	}
+	return cmd
 }
 
 func addModuleInitFlags(startCmd *cobra.Command) {


### PR DESCRIPTION
# Related Github tickets

- a list of github issues that are relevant for this PR
Closes: #798 

# Background

_A short paragraph on test what exactly this PR solves._
Genesis commads are move to a seperate `genesis` sub command in cosmos-sdk v0.47.
This PR adds those genesis commands to the root cmd.
Also creating a new Genutil appmodule, as a genesis message validator is required.

# Testing completed

- [ ] _a list of actions that you've performed to ensure that this PR works as intended_
- [ ] _99% of the times you should have an item: "wrote tests"_

# Breaking changes

- [ ] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
