### PR TITLE
Allow releasing for tags with appended info

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v[0-9]+.[0-9]+.[0-9]+.*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 permissions:
   contents: read


### PR DESCRIPTION
* We need to release for tags like v1.0.0-beta1, which currently doesn't work.  This regex change should alow that
