### PR TITLE
Fix decoding of wasm job payload on execution

### DIFF
--- a/x/scheduler/keeper/keeper.go
+++ b/x/scheduler/keeper/keeper.go
@@ -211,7 +211,6 @@ func (k Keeper) ScheduleNow(ctx sdk.Context, jobID string, in []byte) error {
 			"chain_type", router.GetChainType(),
 			"chain_reference_id", router.GetChainReferenceID(),
 		)
-		panic(err)
 	}
 
 	return err

--- a/x/scheduler/keeper/keeper.go
+++ b/x/scheduler/keeper/keeper.go
@@ -203,14 +203,15 @@ func (k Keeper) ScheduleNow(ctx sdk.Context, jobID string, in []byte) error {
 			sdk.NewAttribute("chainReferenceID", router.GetChainReferenceID()),
 		)
 	} else {
-		panic(err)
 		k.Logger(ctx).Error(
 			"couldn't execute a job",
 			"job_id", jobID,
 			"err", err,
+			"payload", payload,
 			"chain_type", router.GetChainType(),
 			"chain_reference_id", router.GetChainReferenceID(),
 		)
+		panic(err)
 	}
 
 	return err

--- a/x/scheduler/keeper/keeper.go
+++ b/x/scheduler/keeper/keeper.go
@@ -203,6 +203,7 @@ func (k Keeper) ScheduleNow(ctx sdk.Context, jobID string, in []byte) error {
 			sdk.NewAttribute("chainReferenceID", router.GetChainReferenceID()),
 		)
 	} else {
+		panic(err)
 		k.Logger(ctx).Error(
 			"couldn't execute a job",
 			"job_id", jobID,

--- a/x/scheduler/keeper/wasm_handler.go
+++ b/x/scheduler/keeper/wasm_handler.go
@@ -1,8 +1,9 @@
 package keeper
 
 import (
+	"encoding/hex"
 	"encoding/json"
-
+	"fmt"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	"github.com/VolumeFi/whoops"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -27,10 +28,20 @@ func (e ExecuteJobWasmEvent) valid() error {
 	return nil
 }
 
+func (k Keeper) UnmarshallJob(msg []byte) (ExecuteJobWasmEvent, error) {
+	var executeMsg ExecuteJobWasmEvent
+	err := json.Unmarshal(msg, &executeMsg)
+
+	hexString := hex.EncodeToString(executeMsg.Payload)
+
+	executeMsg.Payload = []byte(fmt.Sprintf("{\"hexPayload\":\"%s\"}", hexString))
+
+	return executeMsg, err
+}
+
 func (k Keeper) ExecuteWasmJobEventListener() wasmutil.MessengerFnc {
 	return func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) ([]sdk.Event, [][]byte, error) {
-		var executeMsg ExecuteJobWasmEvent
-		err := json.Unmarshal(msg.Custom, &executeMsg)
+		executeMsg, err := k.UnmarshallJob(msg.Custom)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/x/scheduler/keeper/wasm_handler_test.go
+++ b/x/scheduler/keeper/wasm_handler_test.go
@@ -2,6 +2,8 @@ package keeper_test
 
 import (
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
 
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -105,3 +107,30 @@ var _ = Describe("wasm message handler", func() {
 		})
 	})
 })
+
+func TestKeeper_UnmarshallJob(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         []byte
+		expected      keeper.ExecuteJobWasmEvent
+		expectedError error
+	}{
+		{
+			name:  "Happy Path",
+			input: []byte("{\"job_id\":\"dca_test_job_2\",\"payload\":\"2WBzzwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZmYQoclhTARc=\"}"),
+			expected: keeper.ExecuteJobWasmEvent{
+				JobID:   "dca_test_job_2",
+				Payload: []byte("{\"hexPayload\":\"d96073cf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000199984287258530117\"}"),
+			},
+		},
+	}
+	asserter := assert.New(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testKeeper := keeper.Keeper{}
+			actual, _ := testKeeper.UnmarshallJob(tt.input)
+			asserter.Equal(string(tt.expected.Payload), string(actual.Payload))
+		})
+	}
+}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/169
- https://github.com/VolumeFi/paloma/issues/166

# Background

Executing wasm contracts appears to never have worked.  The executor for these jobs was incorrectly decoding the job payload

# Testing completed

- [x] I added a unit test to ensure the decoding happens correctly

# Breaking changes

- [x] I have checked my code for breaking changes
