### PR TITLE
Fix GLIBC errors seen by some

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,6 +17,8 @@ builds:
       - linux
     goarch:
       - amd64
+    env:
+      - CGO_ENABLED=0
 
 
 archives:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [v1.0.0]
+* (22ced42) Fix GLIBC errors seen by some (#844)
 * (b272a43) Fix decoding of wasm job payload on execution (#833)
 * (ca9aa9c) Tweak matching string because it's not regex (#830)
 * (2a1ad03) Allow releasing for tags with appended info (#829)


### PR DESCRIPTION
# Background

The crux of this issue is that the version of glibc on the github machine that builds this vs that of those who run it may be different. We need to use this env variables build in the libraries instead of dynamically loading them on the host machine at runtime.

# Testing completed

- [x] I built paloma and deployed it to a server that experienced these errors previously.  The errors no longer occur.

# Breaking changes

- [x] I have checked my code for breaking changes