### PR TITLE
Revert "Fix GLIBC errors seen by some"

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,8 +17,6 @@ builds:
       - linux
     goarch:
       - amd64
-    env:
-      - CGO_ENABLED=0
 
 
 archives:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## [v1.0.0]
-* (22ced42) Fix GLIBC errors seen by some (#844)
 * (b272a43) Fix decoding of wasm job payload on execution (#833)
 * (ca9aa9c) Tweak matching string because it's not regex (#830)
 * (2a1ad03) Allow releasing for tags with appended info (#829)


### PR DESCRIPTION
Reverts palomachain/paloma#845

I don't understand why this worked when testing before the PR, but testing after merging, this no longer works.  This needs reverted and deserves more testing before putting it into a future release.

If teams hit the GLIBC error, the fix will be to pull the code and build it themselves for this version.