### PR TITLE
Hotfix/v1.1.0 upgrade fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ See [Release procedure](CONTRIBUTING.md#release-procedure) for more information 
 ## Join an active Network
 
 > #### Note:
-> Some have seen errors with GLIBC version differences with the downloaded binaries for v1.0.0.  This is caused by a difference in the libraries of the host that built the binary and the host running the binary.
+> Some have seen errors with GLIBC version differences with the downloaded binaries for v1.1.0.  This is caused by a difference in the libraries of the host that built the binary and the host running the binary.
 >
-> We did not find this bug in time to fix it in the v1.0.0 release.  Instead there is a workaround.  If you experience these errors, please pull down the code and build it, rather than downloading the prebuilt binary
+> If you experience these errors, please pull down the code and build it, rather than downloading the prebuilt binary
 
 
 ### Install the correct version of libwasm
@@ -78,7 +78,7 @@ rm -r ~/.paloma/data/wasm/cache
 
 ```
 shell
-wget -O - https://github.com/palomachain/paloma/releases/download/v1.0.0/paloma_Linux_x86_64.tar.gz  | \
+wget -O - https://github.com/palomachain/paloma/releases/download/v1.1.0/paloma_Linux_x86_64.tar.gz  | \
   sudo tar -C ~/ -xvzf - palomad
 sudo chmod +x /usr/local/bin/palomad
 ```
@@ -89,7 +89,7 @@ sudo chmod +x /usr/local/bin/palomad
 shell
 git clone https://github.com/palomachain/paloma.git
 cd paloma
-git checkout v1.0.0
+git checkout v1.1.0
 make build
 sudo mv ./build/palomad /usr/local/bin/palomad
 ```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,23 @@
+## What's Changed
+* Allow releasing for tags with appended info by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/829
+* Tweak matching string because it's not regex by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/830
+* Fix decoding of wasm job payload on execution by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/833
+* Bump github.com/onsi/ginkgo/v2 from 2.9.2 to 2.9.4 by @dependabot in https://github.com/palomachain/paloma/pull/825
+* Bump google.golang.org/grpc from 1.54.0 to 1.55.0 by @dependabot in https://github.com/palomachain/paloma/pull/827
+* Bump github.com/docker/distribution from 2.8.1+incompatible to 2.8.2+incompatible by @dependabot in https://github.com/palomachain/paloma/pull/835
+* Fix GLIBC errors seen by some by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/844
+* Add in glibc gotcha and example to build from source by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/847
+* Bump github.com/spf13/cast from 1.5.0 to 1.5.1 by @dependabot in https://github.com/palomachain/paloma/pull/840
+* Bump github.com/onsi/ginkgo/v2 from 2.9.4 to 2.9.5 by @dependabot in https://github.com/palomachain/paloma/pull/841
+* Bump cosmossdk.io/math from 1.0.0 to 1.0.1 by @dependabot in https://github.com/palomachain/paloma/pull/842
+* Revert building with CGO disabled by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/848
+* Run go mod tidy by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/849
+* Update README.md vor new tag by @verabehr in https://github.com/palomachain/paloma/pull/854
+* Update README.md by @verabehr in https://github.com/palomachain/paloma/pull/855
+* Update readme by @verabehr in https://github.com/palomachain/paloma/pull/856
+* Sender public key now being sent with scheduled jobs by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/857
+* Send different identifier for cosmwasm executed jobs by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/858
+* Remove the go mod tidy command from protogen script by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/859
+* Toaster/go mod updates by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/860
+
+**Full Changelog**: https://github.com/palomachain/paloma/compare/v1.0.0...v1.1.0

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -187,7 +187,7 @@ func (app *App) RegisterUpgradeHandlers(semverVersion string) {
 		panic(err)
 	}
 
-	if upgradeInfo.Name == semverVersion && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	if upgradeInfo.Name == "v1.0.0" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Renamed: []storetypes.StoreRename{ // x/consensus module renamed to palomaconsensus
 				{


### PR DESCRIPTION
# Background

When starting up, paloma is attempting to run upgrades meant for a previous version (v1.0.0).  This code should not be dynamic, as all upgrades are different.  We are now specifying the exact version this code is meant to run for.

# Testing completed

- [x] This was tested on a local private testnet

