### PR TITLE
Fixing broken v1.1.0 version

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -187,7 +187,7 @@ func (app *App) RegisterUpgradeHandlers(semverVersion string) {
 		panic(err)
 	}
 
-	if upgradeInfo.Name == semverVersion && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	if upgradeInfo.Name == "v1.0.0" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Renamed: []storetypes.StoreRename{ // x/consensus module renamed to palomaconsensus
 				{


### PR DESCRIPTION
# Background

When starting up, paloma is attempting to run upgrades meant for a previous version (v1.0.0).  This code should not be dynamic, as all upgrades are different.  We are now specifying the exact version this code is meant to run for.

# Testing completed

- [x] This was tested in a local private testnet