### PR TITLE
Slow down rejailing slightly

### DIFF
--- a/x/valset/module.go
+++ b/x/valset/module.go
@@ -164,7 +164,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		}
 	}
 
-	if ctx.BlockHeight()%5 == 0 {
+	if ctx.BlockHeight()%10 == 0 {
 		if err := am.keeper.JailInactiveValidators(ctx); err != nil {
 			am.keeper.Logger(ctx).Error("error while jailing inactive validators", "error", err)
 		}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/254

# Background

This is meant as a stop-gap until we get to a better solution.  Pigeons are rejailed too quickly when unjailing.  We're slowing this process down slightly by not checking quite as often

# Testing completed

- [x] tested in a local private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
