### PR TITLE
Slow down rejailing slightly

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,6 @@
 * Upgrade gogoproto and cosmos-sdk by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/874
 * Lengthen the valset publish keep-warm time by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/881
 * Toaster/module updates by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/882
-
+* Slow down rejailing slightly by @ToasterTheBrave in https://github.com/palomachain/paloma/pull/888
 
 **Full Changelog**: https://github.com/palomachain/paloma/compare/v1.3.0...v1.3.1

--- a/x/valset/module.go
+++ b/x/valset/module.go
@@ -164,7 +164,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		}
 	}
 
-	if ctx.BlockHeight()%5 == 0 {
+	if ctx.BlockHeight()%10 == 0 {
 		if err := am.keeper.JailInactiveValidators(ctx); err != nil {
 			am.keeper.Logger(ctx).Error("error while jailing inactive validators", "error", err)
 		}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/254

# Background

This is meant as a stop-gap until we get to a better solution.  Pigeons are rejailed too quickly when unjailing.  We're slowing this process down slightly by not checking quite as often

# Testing completed

- [x] tested in a local private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
