### PR TITLE
Adding commands for managing snapshots

### DIFF
--- a/cmd/palomad/root.go
+++ b/cmd/palomad/root.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/client/snapshot"
 	"log"
 	"net/http"
 	"net/http/pprof"
@@ -16,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
+	"github.com/cosmos/cosmos-sdk/client/snapshot"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/types/module"

--- a/cmd/palomad/root.go
+++ b/cmd/palomad/root.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/client/snapshot"
 	"log"
 	"net/http"
 	"net/http/pprof"
@@ -157,7 +158,8 @@ func initRootCmd(rootCmd *cobra.Command, ac appCreator) {
 		config.Cmd(),
 	)
 
-	server.AddCommands(rootCmd, palomaapp.DefaultNodeHome, ac.newApp, ac.appExport, addModuleInitFlags)
+	application := ac.newApp
+	server.AddCommands(rootCmd, palomaapp.DefaultNodeHome, application, ac.appExport, addModuleInitFlags)
 
 	// add keybase, auxiliary RPC, query, and tx child commands
 	rootCmd.AddCommand(
@@ -165,6 +167,10 @@ func initRootCmd(rootCmd *cobra.Command, ac appCreator) {
 		queryCommand(ac.moduleManager),
 		txCommand(ac.moduleManager),
 		keys.Commands(palomaapp.DefaultNodeHome),
+	)
+
+	rootCmd.AddCommand(
+		snapshot.Cmd(application),
 	)
 }
 


### PR DESCRIPTION
# Background

This was done as part of a debugging effort, but seems useful to have in palomad.  Using these commands, we can easily manage snapshots ad-hoc

# Testing completed

- [x] Tested on testnet during debugging

# Breaking changes

- [x] I have checked my code for breaking changes
