### PR TITLE
Don't jail when starting up a new chain

### DIFF
--- a/x/valset/module.go
+++ b/x/valset/module.go
@@ -164,7 +164,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		}
 	}
 
-	if ctx.BlockHeight()%10 == 0 {
+	if ctx.BlockHeight() > 50 && ctx.BlockHeight()%10 == 0 {
 		if err := am.keeper.JailInactiveValidators(ctx); err != nil {
 			am.keeper.Logger(ctx).Error("error while jailing inactive validators", "error", err)
 		}


### PR DESCRIPTION
# Background

This really just helps development.  We want to give both Paloma and Pigeon some time before we start worrying about jailing.  Now, we won't jail within the first 50 blocks of a new chain

# Testing completed

- [x] tested in a local private testnet

