### PR TITLE
🔧 fix: #265 remove yaml marshalling in endblock logging

### DIFF
--- a/x/consensus/keeper/attest.go
+++ b/x/consensus/keeper/attest.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -26,7 +24,6 @@ func (k Keeper) CheckAndProcessAttestedMessages(ctx sdk.Context) error {
 					"check-and-process-attested-messages-queue",
 					"id", msg.GetId(),
 					"nonce", msg.Nonce(),
-					"string", fmt.Sprintf("+%v", msg),
 				)
 				cq, err := k.getConsensusQueue(ctx, opt.QueueTypeName)
 				if err != nil {

--- a/x/consensus/types/consensus.go
+++ b/x/consensus/types/consensus.go
@@ -8,7 +8,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
 	xchain "github.com/palomachain/paloma/internal/x-chain"
-	"gopkg.in/yaml.v2"
 )
 
 type ConsensusQueueType string
@@ -63,8 +62,11 @@ type MessageQueuedForBatchingI interface {
 var _ MessageQueuedForBatchingI = &BatchOfConsensusMessages{}
 
 func (q *QueuedSignedMessage) String() string {
-	out, _ := yaml.Marshal(q)
-	return string(out)
+	if q == nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%+v", *q)
 }
 
 func (q *QueuedSignedMessage) AddSignData(data *SignData) {


### PR DESCRIPTION
# Related Github tickets

https://github.com/VolumeFi/paloma/issues/265

# Background

During the endblock handling, the entire message would get logged. The [stringer implementation](https://pkg.go.dev/golang.org/x/tools/cmd/stringer) for the underlaying message type was using the yaml package for a complete string marshalling, which resulted in a large amount of overhead. 

Logging the entire message in byte code not only take quite a long time due to marshalling, it's also largely irrelevant, as message information can easily be obtained from the queue.

# Testing completed

- [x] _a list of actions that you've performed to ensure that this PR works as intended_

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
