### PR TITLE
🔧 fix: ensure jail warning is logged

### DIFF
--- a/x/valset/keeper/keep_alive.go
+++ b/x/valset/keeper/keep_alive.go
@@ -17,7 +17,7 @@ const (
 	defaultKeepAliveDuration        = 5 * time.Minute
 	cValidatorJailedErrorMessage    = "validator is jailed"
 	cValidatorNotBondedErrorMessage = "validator is not bonded"
-	cJailingImminentThreshold       = time.Second * 30
+	cJailingImminentThreshold       = 2 * time.Minute
 )
 
 type keepAliveData struct {


### PR DESCRIPTION
With jailing rounds happening once per minute, a 30 second threshold before TTL runs out might not be printed in time for users to react.

Switching the threshold to two minutes will give them ample to time to investigate the issue and potentially restart pigoen.

# Testing completed

- [x] _a list of actions that you've performed to ensure that this PR works as intended_
- [x] _99% of the times you should have an item: "wrote tests"_

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
