### PR TITLE
Revert "feat: #254 Jail pigeons after timeout"

### DIFF
--- a/x/valset/module.go
+++ b/x/valset/module.go
@@ -3,7 +3,6 @@ package valset
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -20,12 +19,9 @@ import (
 )
 
 var (
-	_            module.AppModule      = AppModule{}
-	_            module.AppModuleBasic = AppModuleBasic{}
-	nextJailTick                       = time.Now().UTC().Add(cJailTickInterval)
+	_ module.AppModule      = AppModule{}
+	_ module.AppModuleBasic = AppModuleBasic{}
 )
-
-const cJailTickInterval = time.Minute
 
 // ----------------------------------------------------------------------------
 // AppModuleBasic
@@ -168,12 +164,10 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		}
 	}
 
-	if ctx.BlockHeight() > 50 && time.Now().UTC().After(nextJailTick) {
+	if ctx.BlockHeight() > 50 && ctx.BlockHeight()%10 == 0 {
 		if err := am.keeper.JailInactiveValidators(ctx); err != nil {
 			am.keeper.Logger(ctx).Error("error while jailing inactive validators", "error", err)
 		}
-
-		nextJailTick = time.Now().UTC().Add(cJailTickInterval)
 	}
 	return []abci.ValidatorUpdate{}
 }


### PR DESCRIPTION
Reverts palomachain/paloma#898

This appears to need some more work (and rolled back until the work is done).  It's causing errors when I run it in my local testnet, and most certainly will in mainnet

If I just kill a pigeon and let it reach the end of the TTL, palomad throws an error and breaks the chain.
```
Jul 05 18:50:31 m2 palomad[78744]: {"level":"error","module":"server","module":"consensus","height":217,"round":6,"err":"wrong Block.Header.AppHash.  Expected 437036D053C17E21AF21717F13B7479982589A423E68D757B8C996D6A2EEDC2F, got DBC723F7850C095868326648BFDE22D9C9AC26205190F5DBC48316DD84A00998","time":"2023-07-05T18:50:31Z","message":"prevote step: consensus deems this block invalid; prevoting nil"}
```

This error means we've created inconsistency between nodes.  The other nodes don't have the same data in their consensus module as this node.