### PR TITLE
Make schedling more spread across validators

### DIFF
--- a/x/evm/keeper/msg_assigner.go
+++ b/x/evm/keeper/msg_assigner.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"errors"
 	"math"
-	"math/rand"
 	"sort"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -189,10 +188,9 @@ func pickValidator(ctx sdk.Context, validatorsInfos map[string]ValidatorInfo, we
 		}
 	}
 
-	// All else equal, grab a random of our high scorers deterministically within this block
-	detRand := rand.New(rand.NewSource(ctx.BlockHeight())) //nolint:gosec
+	// All else equal, grab one of our high scorers, but not always the same one
 	sort.Strings(highScorers)
-	return highScorers[detRand.Intn(len(highScorers))]
+	return highScorers[int(ctx.BlockHeight())%len(highScorers)]
 }
 
 func (ma MsgAssigner) PickValidatorForMessage(ctx sdk.Context, weights *types.RelayWeights) (string, error) {


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/342
- https://github.com/VolumeFi/paloma/issues/118

# Background

I'm seeing the same validator selected too often when trying to be random.  Instead, let's just round-robin through the highest scorers.
* This means a single validator will get all messages for a single block, and a different validator will get all messsages for the next block
* We may want to change this in the future when we have more transactions per block, but for now, this should spread the load more evenly
# Testing completed

- [x] tests already exist and didn't break
- [x] tested in a local private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
