### PR TITLE
#254 Add grace period for freshly unjailed validators

### DIFF
--- a/util/libvalid/nil.go
+++ b/util/libvalid/nil.go
@@ -1,0 +1,21 @@
+package libvalid
+
+import "unsafe"
+
+func IsNil(parameter interface{}) bool {
+	// see https://dev.to/pauljlucas/go-tcha-when-nil--nil-hic
+	return parameter == nil || (*[2]uintptr)(unsafe.Pointer(&parameter))[1] == 0
+}
+
+func NotNil(parameter interface{}) bool {
+	return !IsNil(parameter)
+}
+
+func AnyNil(values ...interface{}) bool {
+	for _, val := range values {
+		if IsNil(val) {
+			return true
+		}
+	}
+	return false
+}

--- a/x/paloma/keeper/keeper.go
+++ b/x/paloma/keeper/keeper.go
@@ -68,7 +68,7 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 
 func (k Keeper) JailValidatorsWithMissingExternalChainInfos(ctx sdk.Context) error {
 	k.Logger(ctx).Info("start jailing validators with invalid external chain infos")
-	vals := k.Valset.UnjailedValidators(ctx)
+	vals := k.Valset.GetUnjailedValidators(ctx)
 
 	// making a map of chain types and their external chains
 	type mapkey [2]string

--- a/x/paloma/types/expected_keepers.go
+++ b/x/paloma/types/expected_keepers.go
@@ -21,7 +21,7 @@ type BankKeeper interface {
 }
 
 type ValsetKeeper interface {
-	UnjailedValidators(ctx sdk.Context) []stakingtypes.ValidatorI
+	GetUnjailedValidators(ctx sdk.Context) []stakingtypes.ValidatorI
 	Jail(ctx sdk.Context, valAddr sdk.ValAddress, reason string) error
 	GetValidatorChainInfos(ctx sdk.Context, valAddr sdk.ValAddress) ([]*valsettypes.ExternalChainInfo, error)
 }

--- a/x/valset/keeper/grpc_query_get_alive_pigeons.go
+++ b/x/valset/keeper/grpc_query_get_alive_pigeons.go
@@ -19,7 +19,7 @@ func (k Keeper) GetAlivePigeons(goCtx context.Context, req *types.QueryGetAliveP
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	vals := k.UnjailedValidators(ctx)
+	vals := k.GetUnjailedValidators(ctx)
 
 	now := time.Now().UTC()
 	res := slice.Map(vals, func(val stakingtypes.ValidatorI) *types.QueryGetAlivePigeonsResponse_ValidatorAlive {

--- a/x/valset/keeper/keep_alive.go
+++ b/x/valset/keeper/keep_alive.go
@@ -172,7 +172,6 @@ func (k Keeper) isValidatorInGracePeriod(ctx sdk.Context, valAddr sdk.ValAddress
 	store := k.gracePeriodStore(ctx)
 	bytes := store.Get(valAddr)
 	return libvalid.NotNil(bytes) && ctx.BlockHeight()-int64(sdk.BigEndianToUint64(bytes)) <= cGracePeriodBlockHeight
-
 }
 
 func (k Keeper) keepAliveStore(ctx sdk.Context) sdk.KVStore {

--- a/x/valset/keeper/keep_alive.go
+++ b/x/valset/keeper/keep_alive.go
@@ -171,7 +171,8 @@ func (k Keeper) JailInactiveValidators(ctx sdk.Context) error {
 func (k Keeper) isValidatorInGracePeriod(ctx sdk.Context, valAddr sdk.ValAddress) bool {
 	store := k.gracePeriodStore(ctx)
 	bytes := store.Get(valAddr)
-	return libvalid.NotNil(bytes) && (uint64(ctx.BlockHeight())-sdk.BigEndianToUint64(bytes)) <= cGracePeriodBlockHeight
+	return libvalid.NotNil(bytes) && ctx.BlockHeight()-int64(sdk.BigEndianToUint64(bytes)) <= cGracePeriodBlockHeight
+
 }
 
 func (k Keeper) keepAliveStore(ctx sdk.Context) sdk.KVStore {

--- a/x/valset/keeper/keep_alive.go
+++ b/x/valset/keeper/keep_alive.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"time"
@@ -9,6 +10,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/palomachain/paloma/util/libvalid"
+	"github.com/palomachain/paloma/util/slice"
 	"github.com/palomachain/paloma/x/valset/types"
 )
 
@@ -17,7 +20,9 @@ const (
 	defaultKeepAliveDuration        = 5 * time.Minute
 	cValidatorJailedErrorMessage    = "validator is jailed"
 	cValidatorNotBondedErrorMessage = "validator is not bonded"
-	cJailingImminentThreshold       = time.Second * 30
+	cJailingImminentThreshold       = 2 * time.Minute
+	cGracePeriodBlockHeight         = 10
+	cUnjailedSnapshotStoreKey       = "unjailed-validators-snapshot"
 )
 
 type keepAliveData struct {
@@ -96,10 +101,41 @@ func (k Keeper) CanAcceptValidator(ctx sdk.Context, valAddr sdk.ValAddress) erro
 	return nil
 }
 
+// UpdateGracePeriod will compare the list of active validators against the
+// snapshot taken during the last block. Any new members will receive a grace
+// period of n blocks.
+// Active validators are stored as one flattened entry to relief pressure on
+// reads every block.
+// Call this during the EndBlock logic.
+func (k Keeper) UpdateGracePeriod(ctx sdk.Context) {
+	us := k.unjailedSnapshotStore(ctx)
+	gs := k.gracePeriodStore(ctx)
+
+	// Retrieve active validators from last block
+	snapshot := bytes.Split(us.Get([]byte(cUnjailedSnapshotStoreKey)), []byte(","))
+	lookup := make(map[string]struct{})
+	for _, v := range snapshot {
+		lookup[string(v)] = struct{}{}
+	}
+
+	vals := slice.Map(k.GetUnjailedValidators(ctx), func(i stakingtypes.ValidatorI) []byte {
+		return i.GetOperator()
+	})
+	for _, v := range vals {
+		if _, found := lookup[string(v)]; !found {
+			// Looks like there's a new unjailed validator. Let's give them
+			// some time before considering jailing them again.
+			gs.Set(v, sdk.Uint64ToBigEndian(uint64(ctx.BlockHeight())))
+		}
+	}
+
+	// Record current snapshot of unjailed validators
+	us.Set([]byte(cUnjailedSnapshotStoreKey), bytes.Join(vals, []byte(",")))
+}
+
 func (k Keeper) JailInactiveValidators(ctx sdk.Context) error {
-	store := k.validatorStore(ctx)
 	var g whoops.Group
-	for _, val := range k.UnjailedValidators(ctx) {
+	for _, val := range k.GetUnjailedValidators(ctx) {
 		if !(val.GetStatus() == stakingtypes.Bonded || val.GetStatus() == stakingtypes.Unbonding) {
 			continue
 		}
@@ -117,7 +153,12 @@ func (k Keeper) JailInactiveValidators(ctx sdk.Context) error {
 		if alive {
 			continue
 		}
-		store.Delete(valAddr)
+
+		if k.isValidatorInGracePeriod(ctx, valAddr) {
+			// Pigeon is not alive, but validator still covered by grace period
+			continue
+		}
+
 		if !k.IsJailed(ctx, valAddr) {
 			g.Add(
 				k.Jail(ctx, valAddr, types.JailReasonPigeonInactive),
@@ -125,6 +166,12 @@ func (k Keeper) JailInactiveValidators(ctx sdk.Context) error {
 		}
 	}
 	return g.Return()
+}
+
+func (k Keeper) isValidatorInGracePeriod(ctx sdk.Context, valAddr sdk.ValAddress) bool {
+	store := k.gracePeriodStore(ctx)
+	bytes := store.Get(valAddr)
+	return libvalid.NotNil(bytes) && (uint64(ctx.BlockHeight())-sdk.BigEndianToUint64(bytes)) <= cGracePeriodBlockHeight
 }
 
 func (k Keeper) keepAliveStore(ctx sdk.Context) sdk.KVStore {

--- a/x/valset/keeper/keep_alive_test.go
+++ b/x/valset/keeper/keep_alive_test.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 	"time"
@@ -14,9 +15,9 @@ import (
 
 func TestJailingInactiveValidators(t *testing.T) {
 	k, ms, ctx := newValsetKeeper(t)
-	ctx = ctx.WithBlockTime(time.Unix(1000000000, 0))
+	ctx = ctx.WithBlockTime(time.Unix(1000000000, 0)).WithBlockHeight(100)
 
-	valBuild := func(id int, toBeJailed bool) *mocks.StakingValidatorI {
+	valBuild := func(id int, toBeJailed bool) (*mocks.StakingValidatorI, sdk.ValAddress) {
 		val := sdk.ValAddress(fmt.Sprintf("validator_%d", id))
 		vali := mocks.NewStakingValidatorI(t)
 		ms.StakingKeeper.On("Validator", mock.Anything, val).Return(vali)
@@ -32,22 +33,91 @@ func TestJailingInactiveValidators(t *testing.T) {
 			err := k.KeepValidatorAlive(ctx.WithBlockTime(ctx.BlockTime().Add(-defaultKeepAliveDuration/2)), val)
 			require.NoError(t, err)
 		}
-		return vali
+		return vali, val
 	}
 
-	v1 := valBuild(1, false)
-	v2 := valBuild(2, false)
-	v3 := valBuild(3, true)
-	v4 := valBuild(4, true)
+	v1, a1 := valBuild(1, false)
+	v2, a2 := valBuild(2, false)
+	v3, a3 := valBuild(3, true)
+	v4, a4 := valBuild(4, true)
+	newUnjailed, _ := valBuild(5, false)
 
+	k.unjailedSnapshotStore(ctx).Set([]byte(cUnjailedSnapshotStoreKey), bytes.Join([][]byte{a1, a2, a3, a4}, []byte(",")))
 	ms.StakingKeeper.On("IterateValidators", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		callback := args.Get(1).(func(int64, stakingtypes.ValidatorI) bool)
 		callback(0, v1)
 		callback(0, v2)
 		callback(0, v3)
 		callback(0, v4)
+		callback(0, newUnjailed)
 	}).Return(false)
 
 	err := k.JailInactiveValidators(ctx)
 	require.NoError(t, err)
+}
+
+func TestUpdateGracePeriod(t *testing.T) {
+	k, ms, ctx := newValsetKeeper(t)
+	ctx = ctx.WithBlockTime(time.Unix(1000000000, 0)).WithBlockHeight(100)
+
+	valBuild := func(id int) (*mocks.StakingValidatorI, sdk.ValAddress) {
+		val := sdk.ValAddress(fmt.Sprintf("validator_%d", id))
+		vali := mocks.NewStakingValidatorI(t)
+		vali.On("IsJailed").Return(false)
+		vali.On("GetOperator").Return(val)
+		return vali, val
+	}
+
+	putSn := func(ctx sdk.Context, vals ...[]byte) {
+		k.unjailedSnapshotStore(ctx).Set([]byte(cUnjailedSnapshotStoreKey), bytes.Join(vals, []byte(",")))
+	}
+
+	v1, a1 := valBuild(1)
+	v2, a2 := valBuild(2)
+	v3, a3 := valBuild(3)
+
+	teardown := func() {
+		k.unjailedSnapshotStore(ctx).Delete([]byte(cUnjailedSnapshotStoreKey))
+		for _, v := range []sdk.ValAddress{a1, a2, a3} {
+			k.gracePeriodStore(ctx).Delete(v)
+		}
+	}
+
+	ms.StakingKeeper.On("IterateValidators", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		callback := args.Get(1).(func(int64, stakingtypes.ValidatorI) bool)
+		callback(0, v1)
+		callback(0, v2)
+		callback(0, v3)
+	}).Return(false)
+
+	t.Run("with no elements in past snapshot", func(t *testing.T) {
+		t.Cleanup(teardown)
+		k.UpdateGracePeriod(ctx)
+		for _, v := range []sdk.ValAddress{a1, a2, a3} {
+			x := int64(sdk.BigEndianToUint64(k.gracePeriodStore(ctx).Get(v)))
+			require.Equal(t, ctx.BlockHeight(), x)
+		}
+	})
+
+	t.Run("with all elements in past snapshot", func(t *testing.T) {
+		t.Cleanup(teardown)
+		putSn(ctx, a1, a2, a3)
+		k.UpdateGracePeriod(ctx)
+		for _, v := range []sdk.ValAddress{a1, a2, a3} {
+			x := k.gracePeriodStore(ctx).Get(v)
+			require.Nil(t, x)
+		}
+	})
+
+	t.Run("with some elements in past snapshot", func(t *testing.T) {
+		t.Cleanup(teardown)
+		putSn(ctx, a1, a3)
+		k.UpdateGracePeriod(ctx)
+		for _, v := range []sdk.ValAddress{a1, a3} {
+			x := k.gracePeriodStore(ctx).Get(v)
+			require.Nil(t, x)
+		}
+		x := int64(sdk.BigEndianToUint64(k.gracePeriodStore(ctx).Get(a2)))
+		require.Equal(t, ctx.BlockHeight(), x)
+	})
 }

--- a/x/valset/keeper/keeper.go
+++ b/x/valset/keeper/keeper.go
@@ -305,7 +305,7 @@ func (k Keeper) isNewSnapshotWorthy(ctx sdk.Context, currentSnapshot, newSnapsho
 	return false
 }
 
-func (k Keeper) UnjailedValidators(ctx sdk.Context) []stakingtypes.ValidatorI {
+func (k Keeper) GetUnjailedValidators(ctx sdk.Context) []stakingtypes.ValidatorI {
 	validators := []stakingtypes.ValidatorI{}
 	k.staking.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) bool {
 		if !val.IsJailed() {
@@ -520,8 +520,12 @@ func (k Keeper) jailReasonStore(ctx sdk.Context) sdk.KVStore {
 	return prefix.NewStore(ctx.KVStore(k.storeKey), []byte("jail-reasons"))
 }
 
-func (k Keeper) validatorStore(ctx sdk.Context) sdk.KVStore {
-	return prefix.NewStore(ctx.KVStore(k.storeKey), []byte("validators"))
+func (k Keeper) gracePeriodStore(ctx sdk.Context) sdk.KVStore {
+	return prefix.NewStore(ctx.KVStore(k.storeKey), []byte("grace-period"))
+}
+
+func (k Keeper) unjailedSnapshotStore(ctx sdk.Context) sdk.KVStore {
+	return prefix.NewStore(ctx.KVStore(k.storeKey), []byte("unjailed-snapshot"))
 }
 
 func (k Keeper) externalChainInfoStore(ctx sdk.Context, val sdk.ValAddress) sdk.KVStore {

--- a/x/valset/module.go
+++ b/x/valset/module.go
@@ -3,7 +3,6 @@ package valset
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -20,12 +19,9 @@ import (
 )
 
 var (
-	_            module.AppModule      = AppModule{}
-	_            module.AppModuleBasic = AppModuleBasic{}
-	nextJailTick                       = time.Now().UTC().Add(cJailTickInterval)
+	_ module.AppModule      = AppModule{}
+	_ module.AppModuleBasic = AppModuleBasic{}
 )
-
-const cJailTickInterval = time.Minute
 
 // ----------------------------------------------------------------------------
 // AppModuleBasic
@@ -168,12 +164,12 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		}
 	}
 
-	if ctx.BlockHeight() > 50 && time.Now().UTC().After(nextJailTick) {
+	am.keeper.UpdateGracePeriod(ctx)
+
+	if ctx.BlockHeight() > 50 && ctx.BlockHeight()%10 == 0 {
 		if err := am.keeper.JailInactiveValidators(ctx); err != nil {
 			am.keeper.Logger(ctx).Error("error while jailing inactive validators", "error", err)
 		}
-
-		nextJailTick = time.Now().UTC().Add(cJailTickInterval)
 	}
 	return []abci.ValidatorUpdate{}
 }


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/254

# Background

This change adds a grace period for freshly unjailed validators,
    preventing them from being jailed again immediately during the
    next run of jailing.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
