### PR TITLE
Ignoring a local directory used for notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ release/
 .DS_Store
 build/
 dist/
+.scratch/
+


### PR DESCRIPTION
# Background

This is a directory commonly used for notes and local data.  Ignoring it in git
