### PR TITLE
Delete messages that are stuck in queues

### DIFF
--- a/x/consensus/keeper/cleanup.go
+++ b/x/consensus/keeper/cleanup.go
@@ -1,0 +1,30 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func (k Keeper) DeleteOldMessages(ctx sdk.Context, blocksAgo int64) error {
+	for _, supportedConsensusQueue := range k.registry.slice {
+		opts, err := supportedConsensusQueue.SupportedQueues(ctx)
+		if err != nil {
+			return err
+		}
+		for _, opt := range opts {
+			msgs, err := k.GetMessagesFromQueue(ctx, opt.QueueTypeName, 9999)
+			if err != nil {
+				return err
+			}
+
+			for _, msg := range msgs {
+				if ctx.BlockHeight()-msg.GetAddedAtBlockHeight() > blocksAgo {
+					err = k.DeleteJob(ctx, opt.QueueTypeName, msg.GetId())
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/x/consensus/keeper/cleanup_test.go
+++ b/x/consensus/keeper/cleanup_test.go
@@ -1,0 +1,91 @@
+package keeper
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/palomachain/paloma/x/consensus/keeper/consensus"
+	"github.com/palomachain/paloma/x/consensus/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteOldMessages(t *testing.T) {
+	testcases := []struct {
+		name          string
+		blocksAgo     int64
+		setup         func() (Keeper, sdk.Context, string)
+		expectedError error
+	}{
+		{
+			name:      "deletes messages over a number of blocks ago, but not messages under",
+			blocksAgo: 50,
+			setup: func() (Keeper, sdk.Context, string) {
+				k, _, ctx := newConsensusKeeper(t)
+				queue := types.Queue(defaultQueueName, chainType, chainReferenceID)
+
+				msgType := &types.SimpleMessage{}
+
+				k.registry.Add(
+					queueSupporter{
+						opt: consensus.ApplyOpts(nil,
+							consensus.WithQueueTypeName(queue),
+							consensus.WithStaticTypeCheck(msgType),
+							consensus.WithBytesToSignCalc(msgType.ConsensusSignBytes()),
+							consensus.WithChainInfo(chainType, chainReferenceID),
+							consensus.WithVerifySignature(func([]byte, []byte, []byte) bool {
+								return true
+							}),
+						),
+					},
+				)
+
+				// Add a message at block 1
+				ctx = ctx.WithBlockHeight(1)
+				err := k.PutMessageInQueue(ctx, queue, &types.SimpleMessage{}, nil)
+				require.NoError(t, err)
+
+				// Add a message at block 10
+				ctx = ctx.WithBlockHeight(10)
+				err = k.PutMessageInQueue(ctx, queue, &types.SimpleMessage{}, nil)
+				require.NoError(t, err)
+
+				// Add a message at block 15
+				ctx = ctx.WithBlockHeight(15)
+				err = k.PutMessageInQueue(ctx, queue, &types.SimpleMessage{}, nil)
+				require.NoError(t, err)
+
+				// Add a message at block 20
+				ctx = ctx.WithBlockHeight(20)
+				err = k.PutMessageInQueue(ctx, queue, &types.SimpleMessage{}, nil)
+				require.NoError(t, err)
+
+				// Advance to block 61
+				ctx = ctx.WithBlockHeight(61)
+
+				return *k, ctx, queue
+			},
+			expectedError: nil,
+		},
+	}
+
+	asserter := assert.New(t)
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			k, ctx, queue := tt.setup()
+
+			msgsInQueue, err := k.GetMessagesFromQueue(ctx, queue, 50)
+			require.NoError(t, err)
+
+			asserter.Equal(4, len(msgsInQueue))
+
+			actualErr := k.DeleteOldMessages(ctx, tt.blocksAgo)
+
+			asserter.Equal(tt.expectedError, actualErr)
+
+			msgsInQueue, err = k.GetMessagesFromQueue(ctx, queue, 50)
+			require.NoError(t, err)
+			asserter.Equal(2, len(msgsInQueue))
+		})
+	}
+}

--- a/x/consensus/module.go
+++ b/x/consensus/module.go
@@ -163,5 +163,12 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 	if err := am.keeper.CheckAndProcessAttestedMessages(ctx); err != nil {
 		am.keeper.Logger(ctx).Error("error while attesting to messages", "err", err)
 	}
+
+	if ctx.BlockHeight()%10 == 0 {
+		err := am.keeper.DeleteOldMessages(ctx, 300)
+		if err != nil {
+			am.keeper.Logger(ctx).Error("error while deleting old messages", "err", err)
+		}
+	}
 	return []abci.ValidatorUpdate{}
 }


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/461

# Background

We sometimes see messages stuck in our queues and need to address this problem.

Every 10 blocks, check the age of the messages currently in the queues. If a message is over 300 blocks (~30 minutes) old, we consider it stuck and delete it.  This prevents stuck messages from filling our queues.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
