### PR TITLE
Better message limit handling

### DIFF
--- a/x/consensus/keeper/attest.go
+++ b/x/consensus/keeper/attest.go
@@ -14,7 +14,7 @@ func (k Keeper) CheckAndProcessAttestedMessages(ctx sdk.Context) error {
 			return err
 		}
 		for _, opt := range opts {
-			msgs, err := k.GetMessagesFromQueue(ctx, opt.QueueTypeName, 9999)
+			msgs, err := k.GetMessagesFromQueue(ctx, opt.QueueTypeName, 0)
 			if err != nil {
 				return err
 			}

--- a/x/consensus/keeper/concensus_keeper.go
+++ b/x/consensus/keeper/concensus_keeper.go
@@ -11,6 +11,8 @@ import (
 	valsettypes "github.com/palomachain/paloma/x/valset/types"
 )
 
+var defaultResponseMessageCount = 1000
+
 // getConsensusQueue gets the consensus queue for the given type.
 func (k Keeper) getConsensusQueue(ctx sdk.Context, queueTypeName string) (consensus.Queuer, error) {
 	for _, q := range k.registry.slice {
@@ -80,7 +82,7 @@ func (k Keeper) PutMessageInQueue(ctx sdk.Context, queueTypeName string, msg con
 
 // GetMessagesForSigning returns messages for a single validator that needs to be signed.
 func (k Keeper) GetMessagesForSigning(ctx sdk.Context, queueTypeName string, valAddress sdk.ValAddress) (msgs []types.QueuedSignedMessageI, err error) {
-	msgs, err = k.GetMessagesFromQueue(ctx, queueTypeName, 1000)
+	msgs, err = k.GetMessagesFromQueue(ctx, queueTypeName, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -95,12 +97,16 @@ func (k Keeper) GetMessagesForSigning(ctx sdk.Context, queueTypeName string, val
 		return true
 	})
 
+	if len(msgs) > defaultResponseMessageCount {
+		msgs = msgs[:defaultResponseMessageCount]
+	}
+
 	return msgs, nil
 }
 
 // GetMessagesForRelaying returns messages for a single validator to relay.
 func (k Keeper) GetMessagesForRelaying(ctx sdk.Context, queueTypeName string, valAddress sdk.ValAddress) (msgs []types.QueuedSignedMessageI, err error) {
-	msgs, err = k.GetMessagesFromQueue(ctx, queueTypeName, 1000)
+	msgs, err = k.GetMessagesFromQueue(ctx, queueTypeName, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -121,12 +127,16 @@ func (k Keeper) GetMessagesForRelaying(ctx sdk.Context, queueTypeName string, va
 		return msg.GetPublicAccessData() == nil && msg.GetErrorData() == nil
 	})
 
+	if len(msgs) > defaultResponseMessageCount {
+		msgs = msgs[:defaultResponseMessageCount]
+	}
+
 	return msgs, nil
 }
 
 // GetMessagesForAttesting returns messages for a single validator to attest.
 func (k Keeper) GetMessagesForAttesting(ctx sdk.Context, queueTypeName string, valAddress sdk.ValAddress) (msgs []types.QueuedSignedMessageI, err error) {
-	msgs, err = k.GetMessagesFromQueue(ctx, queueTypeName, 1000)
+	msgs, err = k.GetMessagesFromQueue(ctx, queueTypeName, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -146,6 +156,10 @@ func (k Keeper) GetMessagesForAttesting(ctx sdk.Context, queueTypeName string, v
 
 		return true
 	})
+
+	if len(msgs) > defaultResponseMessageCount {
+		msgs = msgs[:defaultResponseMessageCount]
+	}
 
 	return msgs, nil
 }

--- a/x/consensus/keeper/concensus_keeper.go
+++ b/x/consensus/keeper/concensus_keeper.go
@@ -152,9 +152,6 @@ func (k Keeper) GetMessagesForAttesting(ctx sdk.Context, queueTypeName string, v
 
 // GetMessagesFromQueue gets N messages from the queue.
 func (k Keeper) GetMessagesFromQueue(ctx sdk.Context, queueTypeName string, n int) (msgs []types.QueuedSignedMessageI, err error) {
-	if n <= 0 {
-		return nil, ErrInvalidLimitValue.Format(n)
-	}
 	cq, err := k.getConsensusQueue(ctx, queueTypeName)
 	if err != nil {
 		k.Logger(ctx).Error("error while getting consensus queue", "err", err)
@@ -167,7 +164,7 @@ func (k Keeper) GetMessagesFromQueue(ctx sdk.Context, queueTypeName string, n in
 		return nil, err
 	}
 
-	if len(msgs) > n {
+	if n > 0 && len(msgs) > n {
 		msgs = msgs[:n]
 	}
 

--- a/x/consensus/keeper/concensus_keeper_test.go
+++ b/x/consensus/keeper/concensus_keeper_test.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/cometbft/cometbft/crypto/secp256k1"
@@ -11,6 +10,7 @@ import (
 	"github.com/palomachain/paloma/x/consensus/types"
 	consensustypemocks "github.com/palomachain/paloma/x/consensus/types/mocks"
 	valsettypes "github.com/palomachain/paloma/x/valset/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )

--- a/x/consensus/keeper/grpc_query_messages_in_queue.go
+++ b/x/consensus/keeper/grpc_query_messages_in_queue.go
@@ -17,7 +17,7 @@ func (k Keeper) MessagesInQueue(goCtx context.Context, req *types.QueryMessagesI
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	msgs, err := k.GetMessagesFromQueue(ctx, req.QueueTypeName, 200)
+	msgs, err := k.GetMessagesFromQueue(ctx, req.QueueTypeName, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -874,7 +874,7 @@ func (m msgSender) SendValsetMsgForChain(ctx sdk.Context, chainInfo *types.Chain
 	// clear all other instances of the update valset from the queue
 	m.Logger(ctx).Info("clearing previous instances of the update valset from the queue")
 	queueName := consensustypes.Queue(ConsensusTurnstoneMessage, xchainType, xchain.ReferenceID(chainInfo.GetChainReferenceID()))
-	messages, err := m.ConsensusKeeper.GetMessagesFromQueue(ctx, queueName, 999)
+	messages, err := m.ConsensusKeeper.GetMessagesFromQueue(ctx, queueName, 0)
 	if err != nil {
 		m.Logger(ctx).Error("unable to get messages from queue", "err", err)
 		return err


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/461

# Background

This will help with a couple things
1. If a single pigeon is acting up and leaving all of their messages in the queue, other pigeons will still get their messages.  A single pigeon's messages can no longer block other messges
2. If our queue is overfull, we can now see all messages currently in the queue, not just the first 200

Work done:
* Don't always require a limit on messages
  * Adding an option to get all messages, not just N messages.  This is useful for times when we are going to filter the messages downstream.
* Move message response counts
  * If we request a number of messages, we want that to be the number
    returned, not the number before filtering
  * Also fixing places that wanted all messages.  Now that we can return
    all, let's just request all
* Return all messages for requested messages in queue
  * This is used for the cli command

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
