### PR TITLE
Removing unnecessary output in logs using Println

### DIFF
--- a/x/scheduler/client/cli/tx_create_job.go
+++ b/x/scheduler/client/cli/tx_create_job.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"io/ioutil"
 	"strconv"
 
@@ -59,7 +58,6 @@ func CmdCreateJob() *cobra.Command {
 				Creator: clientCtx.GetFromAddress().String(),
 				Job:     job,
 			}
-			fmt.Printf("[MsgCreateJob][cmdCreateJob][msg] UNPACK ARGS: %+v\n", msg)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/scheduler/keeper/keeper.go
+++ b/x/scheduler/keeper/keeper.go
@@ -91,7 +91,6 @@ func (k Keeper) jobsStore(ctx sdk.Context) sdk.KVStore {
 }
 
 func (k Keeper) AddNewJob(ctx sdk.Context, job *types.Job) (sdk.AccAddress, error) {
-	fmt.Printf("[MsgCreateJob][AddNewJob][job] UNPACK ARGS: %+v\n", job)
 	if k.JobIDExists(ctx, job.GetID()) {
 		return nil, types.ErrJobWithIDAlreadyExists.Wrap(job.GetID())
 	}
@@ -124,7 +123,6 @@ func (k Keeper) AddNewJob(ctx sdk.Context, job *types.Job) (sdk.AccAddress, erro
 }
 
 func (k Keeper) saveJob(ctx sdk.Context, job *types.Job) error {
-	fmt.Printf("[MsgCreateJob][saveJob][job] UNPACK ARGS: %+v\n", job)
 	if job.GetOwner().Empty() {
 		return types.ErrInvalid.Wrap("owner can't be empty when adding a new job")
 	}

--- a/x/scheduler/keeper/msg_server_create_job.go
+++ b/x/scheduler/keeper/msg_server_create_job.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/palomachain/paloma/x/scheduler/types"
@@ -12,7 +11,6 @@ func (k msgServer) CreateJob(goCtx context.Context, msg *types.MsgCreateJob) (*t
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	var err error
-	fmt.Printf("[MsgCreateJob][CreateJob][msg] UNPACK ARGS: %+v\n", msg)
 	job := msg.Job
 	job.Owner, err = sdk.AccAddressFromBech32(msg.GetCreator())
 	if err != nil {

--- a/x/scheduler/types/job.go
+++ b/x/scheduler/types/job.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -12,7 +11,6 @@ const JobIDMaxLen = 32
 const JobAddressLength = 32
 
 func (j *Job) ValidateBasic() error {
-	fmt.Printf("[MsgCreateJob][ValidateBasic][job] UNPACK ARGS: %+v\n", j)
 	if len(j.ID) == 0 {
 		return ErrInvalid.Wrap("job id can't be empty")
 	}

--- a/x/scheduler/types/message_create_job.go
+++ b/x/scheduler/types/message_create_job.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -39,7 +37,6 @@ func (msg *MsgCreateJob) GetSignBytes() []byte {
 }
 
 func (msg *MsgCreateJob) ValidateBasic() error {
-	fmt.Printf("[MsgCreateJob][ValidateBasic][msg] UNPACK ARGS: %+v\n", msg)
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)


### PR DESCRIPTION
# Background

This output looks like it was put in a long time ago while debugging.  It's not using the log package, and it doesn't look like useful information to log.  Removing it to clean up our logs a bit.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
