### PR TITLE
Temporarily remove slashing functionality from Gravity

### DIFF
--- a/x/gravity/abci.go
+++ b/x/gravity/abci.go
@@ -26,7 +26,7 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
 
 // EndBlocker is called at the end of every block
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
-	//outgoingTxSlashing(ctx, k)
+	// outgoingTxSlashing(ctx, k)
 	eventVoteRecordTally(ctx, k)
 	updateObservedEthereumHeight(ctx, k)
 }
@@ -272,6 +272,7 @@ func cleanupTimedOutContractCallTxs(ctx sdk.Context, k keeper.Keeper) {
 	})
 }
 
+//nolint:unused
 func outgoingTxSlashing(ctx sdk.Context, k keeper.Keeper) {
 	params := k.GetParams(ctx)
 	maxHeight := uint64(0)

--- a/x/gravity/abci.go
+++ b/x/gravity/abci.go
@@ -26,7 +26,7 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
 
 // EndBlocker is called at the end of every block
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
-	outgoingTxSlashing(ctx, k)
+	//outgoingTxSlashing(ctx, k)
 	eventVoteRecordTally(ctx, k)
 	updateObservedEthereumHeight(ctx, k)
 }

--- a/x/gravity/abci_test.go
+++ b/x/gravity/abci_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	//slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	// slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"github.com/ethereum/go-ethereum/common"


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/431

# Background

Until we finish adding the gravity features to Pigeon, we need to disable slashing in the gravity module.  We want this back, so it's just commented out for now to prevent buggy behavior in testnet.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
