### PR TITLE
Increase minimum pigeon version

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -141,7 +141,7 @@ const (
 
 	wasmAvailableCapabilities = "iterator,staking,stargate,paloma"
 
-	minimumPigeonVersion = "v1.4.0"
+	minimumPigeonVersion = "v1.5.0"
 )
 
 func getGovProposalHandlers() []govclient.ProposalHandler {


### PR DESCRIPTION
# Background

This release of Paloma requires features from the paired pigeon release in order to function properly.  Pigeons that are not at this version will be jailed.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
