### PR TITLE
Fix the extract location for palomad

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ rm -r ~/.paloma/data/wasm/cache
 
 ```shell
 wget -O - https://github.com/palomachain/paloma/releases/download/v1.6.1/paloma_Linux_x86_64.tar.gz  | \
-  sudo tar -C ~/ -xvzf - palomad
+  sudo tar -C /usr/local/bin -xvzf - palomad
 sudo chmod +x /usr/local/bin/palomad
 ```
 


### PR DESCRIPTION
# Background

This appears to have been incorrect for a while.  It was downloading and extracting palomad into the home directory, rather than /usr/local/bin.  Correcting it.
