### PR TITLE
Publish valset to all chains when returning from a software update

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -181,6 +181,23 @@ func (app *App) RegisterUpgradeHandlers(semverVersion string) {
 				return vm, err
 			}
 
+			// Try to build a snapshot.  Fails silently if unworthy
+			_, err = app.ValsetKeeper.TriggerSnapshotBuild(ctx)
+			if err != nil {
+				return vm, err
+			}
+
+			snapshot, err := app.ValsetKeeper.GetCurrentSnapshot(ctx)
+			if err != nil {
+				return vm, err
+			}
+
+			// Publish latest snapshot to all chains
+			err = app.EvmKeeper.PublishSnapshotToAllChains(ctx, snapshot, true)
+			if err != nil {
+				return vm, err
+			}
+
 			return vm, nil
 		},
 	)

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math/big"
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -15,44 +16,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildKeeper(t *testing.T) (*Keeper, sdk.Context) {
+type validatorChainInfo struct {
+	chainType        string
+	chainReferenceID string
+}
+
+func getValidators(num int, chains []validatorChainInfo) []valsettypes.Validator {
+	validators := make([]valsettypes.Validator, num)
+	for i := 0; i < num; i++ {
+		chainInfos := make([]*valsettypes.ExternalChainInfo, len(chains))
+		for i, chain := range chains {
+			chainInfos[i] = &valsettypes.ExternalChainInfo{
+				ChainType:        chain.chainType,
+				ChainReferenceID: chain.chainReferenceID,
+			}
+		}
+		validators[i] = valsettypes.Validator{
+			State:              valsettypes.ValidatorState_ACTIVE,
+			ShareCount:         sdk.NewInt(25000),
+			ExternalChainInfos: chainInfos,
+		}
+	}
+	return validators
+}
+
+func buildKeeper(t *testing.T) (*Keeper, sdk.Context, mockedServices) {
 	k, mockServices, ctx := NewEvmKeeper(t)
 
 	unpublishedSnapshot := &valsettypes.Snapshot{
 		Id:          1,
 		TotalShares: sdk.NewInt(75000),
-		Validators: []valsettypes.Validator{
-			{
-				State:      valsettypes.ValidatorState_ACTIVE,
-				ShareCount: sdk.NewInt(25000),
-				ExternalChainInfos: []*valsettypes.ExternalChainInfo{
-					{
-						ChainType:        "evm",
-						ChainReferenceID: "test-chain",
-					},
+		Validators: getValidators(
+			3,
+			[]validatorChainInfo{
+				{
+					chainType:        "evm",
+					chainReferenceID: "test-chain",
 				},
 			},
-			{
-				State:      valsettypes.ValidatorState_ACTIVE,
-				ShareCount: sdk.NewInt(25000),
-				ExternalChainInfos: []*valsettypes.ExternalChainInfo{
-					{
-						ChainType:        "evm",
-						ChainReferenceID: "test-chain",
-					},
-				},
-			},
-			{
-				State:      valsettypes.ValidatorState_ACTIVE,
-				ShareCount: sdk.NewInt(25000),
-				ExternalChainInfos: []*valsettypes.ExternalChainInfo{
-					{
-						ChainType:        "evm",
-						ChainReferenceID: "test-chain",
-					},
-				},
-			},
-		},
+		),
 	}
 	// test-chain mocks
 	mockServices.ValsetKeeper.On("GetCurrentSnapshot", mock.Anything).Return(unpublishedSnapshot, nil)
@@ -117,7 +119,7 @@ func buildKeeper(t *testing.T) (*Keeper, sdk.Context) {
 	)
 	require.NoError(t, err)
 
-	return k, ctx
+	return k, ctx, mockServices
 }
 
 func TestKeeper_PreJobExecution(t *testing.T) {
@@ -313,7 +315,7 @@ func TestKeeper_PreJobExecution(t *testing.T) {
 	asserter := assert.New(t)
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
-			k, ctx := buildKeeper(t)
+			k, ctx, _ := buildKeeper(t)
 			tt.setupMocks(ctx, k)
 			job := &schedulertypes.Job{
 				ID: "test_job_1",
@@ -441,12 +443,114 @@ func TestKeeper_MissingChains(t *testing.T) {
 	asserter := assert.New(t)
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
-			k, ctx := buildKeeper(t)
+			k, ctx, _ := buildKeeper(t)
 			tt.setup(ctx, k)
 
 			actual, actualErr := k.MissingChains(ctx, tt.inputChainReferenceIDs)
 			asserter.Equal(tt.expected, actual)
 			asserter.Equal(len(tt.expected), len(actual))
+			asserter.Equal(tt.expectedError, actualErr)
+		})
+	}
+}
+
+func TestKeeper_PublishSnapshotToAllChains(t *testing.T) {
+	testcases := []struct {
+		name          string
+		setup         func(sdk.Context, *Keeper, mockedServices)
+		forcePublish  bool
+		expectedError error
+	}{
+		{
+			name: "Publishes when no previous snapshot on the chain",
+			setup: func(ctx sdk.Context, k *Keeper, ms mockedServices) {
+				ms.ValsetKeeper.On("GetLatestSnapshotOnChain", mock.Anything, mock.Anything).Return(nil, nil)
+				// SendValsetMsgForChain indicates a publish
+				ms.MsgSender.On("SendValsetMsgForChain", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+		},
+		{
+			name: "Doesn't publish when latest valset not over a month old and not forcePublish",
+			setup: func(ctx sdk.Context, k *Keeper, ms mockedServices) {
+				validators := getValidators(
+					3,
+					[]validatorChainInfo{
+						{
+							chainType:        "evm",
+							chainReferenceID: "test-chain",
+						},
+						{
+							chainType:        "evm",
+							chainReferenceID: "test-chain",
+						},
+					},
+				)
+				publishedSnapshot := &valsettypes.Snapshot{
+					Id:          1,
+					Chains:      []string{"test-chain"},
+					TotalShares: sdk.NewInt(75000),
+					Validators:  validators,
+					CreatedAt:   time.Now().Add(time.Duration(-28*24) * time.Hour), // 28 days ago
+				}
+
+				ms.ValsetKeeper.On("GetLatestSnapshotOnChain", mock.Anything, mock.Anything).Return(publishedSnapshot, nil)
+				// Lack of a call to SendValsetMsgForChain indicates no publish
+			},
+		},
+		{
+			name: "Publishes regardless of age when force publish requested",
+			setup: func(ctx sdk.Context, k *Keeper, ms mockedServices) {
+				validators := getValidators(
+					3,
+					[]validatorChainInfo{
+						{
+							chainType:        "evm",
+							chainReferenceID: "test-chain",
+						},
+						{
+							chainType:        "evm",
+							chainReferenceID: "test-chain",
+						},
+					},
+				)
+				publishedSnapshot := &valsettypes.Snapshot{
+					Id:          1,
+					Chains:      []string{"test-chain"},
+					TotalShares: sdk.NewInt(75000),
+					Validators:  validators,
+					CreatedAt:   time.Now().Add(time.Duration(-28*24) * time.Hour), // 28 days ago
+				}
+
+				ms.ValsetKeeper.On("GetLatestSnapshotOnChain", mock.Anything, mock.Anything).Return(publishedSnapshot, nil)
+				// SendValsetMsgForChain indicates a publish
+				ms.MsgSender.On("SendValsetMsgForChain", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			forcePublish: true,
+		},
+	}
+
+	asserter := assert.New(t)
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			k, ctx, mockServices := buildKeeper(t)
+			tt.setup(ctx, k, mockServices)
+
+			ctx = ctx.WithBlockTime(time.Now())
+			newSnapshot := &valsettypes.Snapshot{
+				Id:          2,
+				TotalShares: sdk.NewInt(75000),
+				Validators: getValidators(
+					3,
+					[]validatorChainInfo{
+						{
+							chainType:        "evm",
+							chainReferenceID: "test-chain",
+						},
+					},
+				),
+			}
+
+			actualErr := k.PublishSnapshotToAllChains(ctx, newSnapshot, tt.forcePublish)
 			asserter.Equal(tt.expectedError, actualErr)
 		})
 	}

--- a/x/treasury/keeper/keeper_test.go
+++ b/x/treasury/keeper/keeper_test.go
@@ -342,7 +342,7 @@ func TestGetFees(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 					mock.Anything,
-				).Return(&types.Fees{}, keeperutil.ErrNotFound)
+				).Return(&types.Fees{}, keeperutil.ErrNotFound.Format(&types.Fees{}, ""))
 
 				store := mocks.NewTreasuryStore(t)
 				store.On("TreasuryStore", mock.Anything).Return(nil)

--- a/x/valset/keeper/keeper.go
+++ b/x/valset/keeper/keeper.go
@@ -420,8 +420,8 @@ func (k Keeper) GetLatestSnapshotOnChain(ctx sdk.Context, chainReferenceID strin
 		}
 	}
 
-	k.Logger(ctx).Error("unable to get latest snapshot", "err", keeperutil.ErrNotFound)
-	return nil, keeperutil.ErrNotFound
+	// If we made it here, we didn't find a snapshot for this chain
+	return nil, keeperutil.ErrNotFound.Format(&types.Snapshot{}, snapshotIDKey)
 }
 
 // GetCurrentSnapshot returns the currently active snapshot.


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/608

# Background

Adding the ability to force publish a valset to all chains.  Then taking this ability and applying it to when we come back from an upgrade.

We are very often just above 2/3 previous consensus when we come back from an upgrade, so we should publish the valset that has changed by that much, in case any validators have trouble right after the upgrade and go offline.

Adding some test cases adjacent to this new code, just to test the different paths

There is also a small logging fmt bug fix in here because it finally annoyed me too much.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
