### PR TITLE
Add cli command to delete any stuck smart contract deployments

### DIFF
--- a/proto/palomachain/paloma/evm/tx.proto
+++ b/proto/palomachain/paloma/evm/tx.proto
@@ -5,6 +5,7 @@ option go_package = "github.com/palomachain/paloma/x/evm/types";
 
 service Msg {
     rpc DeployNewSmartContract(MsgDeployNewSmartContractRequest) returns (DeployNewSmartContractResponse);
+    rpc RemoveSmartContractDeployment(MsgRemoveSmartContractDeploymentRequest) returns (RemoveSmartContractDeploymentResponse);
 }
 
 message MsgDeployNewSmartContractRequest {
@@ -16,3 +17,10 @@ message MsgDeployNewSmartContractRequest {
   string bytecodeHex = 5; 
 }
 message DeployNewSmartContractResponse {}
+
+message MsgRemoveSmartContractDeploymentRequest {
+  string Sender = 1;
+  uint64 smartContractID = 2;
+  string chainReferenceID = 3;
+}
+message RemoveSmartContractDeploymentResponse {}

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -22,6 +22,7 @@ func GetTxCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(CmdDeploySmartContract())
+	cmd.AddCommand(CmdRemoveSmartContractDeployment())
 
 	return cmd
 }

--- a/x/evm/client/cli/tx_remove_smart_contract_deployment.go
+++ b/x/evm/client/cli/tx_remove_smart_contract_deployment.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/VolumeFi/whoops"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/palomachain/paloma/x/evm/types"
+	"github.com/spf13/cobra"
+)
+
+func CmdRemoveSmartContractDeployment() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove-smart-contract-deployment smart-contract-id chain-reference-id",
+		Short: "Used to remove a stuck smart contract deployment.  The smart contract will attempt to redeploy automatically",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve ctx: %w", err)
+			}
+
+			smartContractID, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("unable to parse smart-contract-id %s as uint64", args[0])
+			}
+			chainReferenceID := args[1]
+
+			msg := &types.MsgRemoveSmartContractDeploymentRequest{
+				Sender:           clientCtx.GetFromAddress().String(),
+				SmartContractID:  uint64(smartContractID),
+				ChainReferenceID: chainReferenceID,
+			}
+
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			whoops.Assert(err)
+			return nil
+		},
+	}
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/evm/keeper/attest.go
+++ b/x/evm/keeper/attest.go
@@ -110,7 +110,7 @@ func (k Keeper) attestRouter(ctx sdk.Context, q consensus.Queuer, msg consensust
 	case *types.Message_UploadSmartContract:
 		defer func() {
 			// regardless of the outcome, this upload/deployment should be removed
-			k.RemoveSmartContractDeployment(ctx, origMsg.UploadSmartContract.GetId(), chainReferenceID)
+			k.DeleteSmartContractDeployment(ctx, origMsg.UploadSmartContract.GetId(), chainReferenceID)
 		}()
 		switch winner := evidence.(type) {
 		case *types.TxExecutedProof:

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -350,7 +350,7 @@ func (k Keeper) ActivateChainReferenceID(
 	chainInfo.SmartContractAddr = smartContractAddr
 	chainInfo.SmartContractUniqueID = smartContractUniqueID
 
-	k.RemoveSmartContractDeployment(ctx, smartContract.GetId(), chainInfo.GetChainReferenceID())
+	k.DeleteSmartContractDeployment(ctx, smartContract.GetId(), chainInfo.GetChainReferenceID())
 
 	return k.updateChainInfo(ctx, chainInfo)
 }

--- a/x/evm/keeper/keeper_integration_test.go
+++ b/x/evm/keeper/keeper_integration_test.go
@@ -823,7 +823,7 @@ var _ = Describe("evm", func() {
 					})
 
 					By("removing a smart deployment for chain1 - it means that it was successfully uploaded", func() {
-						a.EvmKeeper.RemoveSmartContractDeployment(ctx, smartContract.GetId(), chain1.GetChainReferenceID())
+						a.EvmKeeper.DeleteSmartContractDeployment(ctx, smartContract.GetId(), chain1.GetChainReferenceID())
 						Expect(
 							a.EvmKeeper.HasAnySmartContractDeployment(ctx, chain1.GetChainReferenceID()),
 						).To(BeFalse())

--- a/x/evm/keeper/msg_server_remove_smart_contract_deployment.go
+++ b/x/evm/keeper/msg_server_remove_smart_contract_deployment.go
@@ -1,0 +1,13 @@
+package keeper
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/palomachain/paloma/x/evm/types"
+)
+
+func (k Keeper) RemoveSmartContractDeployment(ctx context.Context, req *types.MsgRemoveSmartContractDeploymentRequest) (*types.RemoveSmartContractDeploymentResponse, error) {
+	k.DeleteSmartContractDeployment(sdk.UnwrapSDKContext(ctx), req.SmartContractID, req.ChainReferenceID)
+	return &types.RemoveSmartContractDeploymentResponse{}, nil
+}

--- a/x/evm/keeper/msg_server_remove_smart_contract_deployment_test.go
+++ b/x/evm/keeper/msg_server_remove_smart_contract_deployment_test.go
@@ -1,0 +1,69 @@
+package keeper
+
+import (
+	"math/big"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/palomachain/paloma/x/evm/types"
+	valsettypes "github.com/palomachain/paloma/x/valset/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func addDeploymentToKeeper(t *testing.T, ctx sdk.Context, k *Keeper, mockServices mockedServices) {
+	unpublishedSnapshot := &valsettypes.Snapshot{
+		Id:          1,
+		TotalShares: sdk.NewInt(75000),
+		Validators: getValidators(
+			3,
+			[]validatorChainInfo{
+				{
+					chainType:        "evm",
+					chainReferenceID: "test-chain",
+				},
+			},
+		),
+	}
+	// test-chain mocks
+	mockServices.ValsetKeeper.On("GetCurrentSnapshot", mock.Anything).Return(unpublishedSnapshot, nil)
+	mockServices.ConsensusKeeper.On("PutMessageInQueue", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	// Add a new chains for our test to use
+	err := k.AddSupportForNewChain(
+		ctx,
+		"test-chain",
+		1,
+		uint64(123),
+		"0x1234",
+		big.NewInt(55),
+	)
+	require.NoError(t, err)
+
+	sc, err := k.SaveNewSmartContract(ctx, contractAbi, common.FromHex(contractBytecodeStr))
+	require.NoError(t, err)
+	err = k.SetAsCompassContract(ctx, sc)
+	require.NoError(t, err)
+}
+
+func TestKeeper_RemoveSmartContractDeployment(t *testing.T) {
+	t.Run("removes a smart contract deployment", func(t *testing.T) {
+		k, mockServices, ctx := NewEvmKeeper(t)
+		addDeploymentToKeeper(t, ctx, k, mockServices)
+
+		deployments, err := k.AllSmartContractsDeployments(ctx)
+		require.Len(t, deployments, 1)
+		require.NoError(t, err)
+
+		_, err = k.RemoveSmartContractDeployment(ctx, &types.MsgRemoveSmartContractDeploymentRequest{
+			SmartContractID:  1,
+			ChainReferenceID: "test-chain",
+		})
+		require.NoError(t, err)
+
+		deployments, err = k.AllSmartContractsDeployments(ctx)
+		require.Len(t, deployments, 0)
+		require.NoError(t, err)
+	})
+}

--- a/x/evm/keeper/smart_contract_deployment.go
+++ b/x/evm/keeper/smart_contract_deployment.go
@@ -45,7 +45,7 @@ func (k Keeper) HasAnySmartContractDeployment(ctx sdk.Context, chainReferenceID 
 	return
 }
 
-func (k Keeper) RemoveSmartContractDeployment(ctx sdk.Context, smartContractID uint64, chainReferenceID string) {
+func (k Keeper) DeleteSmartContractDeployment(ctx sdk.Context, smartContractID uint64, chainReferenceID string) {
 	_, key := k.getSmartContractDeployment(ctx, smartContractID, chainReferenceID)
 	if key == nil {
 		return

--- a/x/evm/types/codec.go
+++ b/x/evm/types/codec.go
@@ -12,6 +12,7 @@ import (
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgDeployNewSmartContractRequest{}, "evm/DeployNewSmartContract", nil)
+	cdc.RegisterConcrete(&MsgRemoveSmartContractDeploymentRequest{}, "evm/DeleteSmartContractDeployment", nil)
 	cdc.RegisterConcrete(&RelayWeightsProposal{}, "evm/RelayWeightsProposal", nil)
 }
 
@@ -19,6 +20,7 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations(
 		(*sdk.Msg)(nil),
 		&MsgDeployNewSmartContractRequest{},
+		&MsgRemoveSmartContractDeploymentRequest{},
 	)
 	registry.RegisterImplementations(
 		(*govv1beta1types.Content)(nil),

--- a/x/evm/types/msg_remove_smart_contract_deployment_request.go
+++ b/x/evm/types/msg_remove_smart_contract_deployment_request.go
@@ -1,0 +1,23 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+func (msg *MsgRemoveSmartContractDeploymentRequest) ValidateBasic() error {
+	_, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+	}
+
+	return nil
+}
+
+func (msg *MsgRemoveSmartContractDeploymentRequest) GetSigners() []sdk.AccAddress {
+	creator, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{creator}
+}

--- a/x/evm/types/tx.pb.go
+++ b/x/evm/types/tx.pb.go
@@ -139,34 +139,140 @@ func (m *DeployNewSmartContractResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DeployNewSmartContractResponse proto.InternalMessageInfo
 
+type MsgRemoveSmartContractDeploymentRequest struct {
+	Sender           string `protobuf:"bytes,1,opt,name=Sender,proto3" json:"Sender,omitempty"`
+	SmartContractID  uint64 `protobuf:"varint,2,opt,name=smartContractID,proto3" json:"smartContractID,omitempty"`
+	ChainReferenceID string `protobuf:"bytes,3,opt,name=chainReferenceID,proto3" json:"chainReferenceID,omitempty"`
+}
+
+func (m *MsgRemoveSmartContractDeploymentRequest) Reset() {
+	*m = MsgRemoveSmartContractDeploymentRequest{}
+}
+func (m *MsgRemoveSmartContractDeploymentRequest) String() string { return proto.CompactTextString(m) }
+func (*MsgRemoveSmartContractDeploymentRequest) ProtoMessage()    {}
+func (*MsgRemoveSmartContractDeploymentRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_631cfc68eb1fd278, []int{2}
+}
+func (m *MsgRemoveSmartContractDeploymentRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgRemoveSmartContractDeploymentRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgRemoveSmartContractDeploymentRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgRemoveSmartContractDeploymentRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgRemoveSmartContractDeploymentRequest.Merge(m, src)
+}
+func (m *MsgRemoveSmartContractDeploymentRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgRemoveSmartContractDeploymentRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgRemoveSmartContractDeploymentRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgRemoveSmartContractDeploymentRequest proto.InternalMessageInfo
+
+func (m *MsgRemoveSmartContractDeploymentRequest) GetSender() string {
+	if m != nil {
+		return m.Sender
+	}
+	return ""
+}
+
+func (m *MsgRemoveSmartContractDeploymentRequest) GetSmartContractID() uint64 {
+	if m != nil {
+		return m.SmartContractID
+	}
+	return 0
+}
+
+func (m *MsgRemoveSmartContractDeploymentRequest) GetChainReferenceID() string {
+	if m != nil {
+		return m.ChainReferenceID
+	}
+	return ""
+}
+
+type RemoveSmartContractDeploymentResponse struct {
+}
+
+func (m *RemoveSmartContractDeploymentResponse) Reset()         { *m = RemoveSmartContractDeploymentResponse{} }
+func (m *RemoveSmartContractDeploymentResponse) String() string { return proto.CompactTextString(m) }
+func (*RemoveSmartContractDeploymentResponse) ProtoMessage()    {}
+func (*RemoveSmartContractDeploymentResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_631cfc68eb1fd278, []int{3}
+}
+func (m *RemoveSmartContractDeploymentResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *RemoveSmartContractDeploymentResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_RemoveSmartContractDeploymentResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *RemoveSmartContractDeploymentResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RemoveSmartContractDeploymentResponse.Merge(m, src)
+}
+func (m *RemoveSmartContractDeploymentResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *RemoveSmartContractDeploymentResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_RemoveSmartContractDeploymentResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RemoveSmartContractDeploymentResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*MsgDeployNewSmartContractRequest)(nil), "palomachain.paloma.evm.MsgDeployNewSmartContractRequest")
 	proto.RegisterType((*DeployNewSmartContractResponse)(nil), "palomachain.paloma.evm.DeployNewSmartContractResponse")
+	proto.RegisterType((*MsgRemoveSmartContractDeploymentRequest)(nil), "palomachain.paloma.evm.MsgRemoveSmartContractDeploymentRequest")
+	proto.RegisterType((*RemoveSmartContractDeploymentResponse)(nil), "palomachain.paloma.evm.RemoveSmartContractDeploymentResponse")
 }
 
 func init() { proto.RegisterFile("palomachain/paloma/evm/tx.proto", fileDescriptor_631cfc68eb1fd278) }
 
 var fileDescriptor_631cfc68eb1fd278 = []byte{
-	// 290 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2f, 0x48, 0xcc, 0xc9,
-	0xcf, 0x4d, 0x4c, 0xce, 0x48, 0xcc, 0xcc, 0xd3, 0x87, 0xb0, 0xf5, 0x53, 0xcb, 0x72, 0xf5, 0x4b,
-	0x2a, 0xf4, 0x0a, 0x8a, 0xf2, 0x4b, 0xf2, 0x85, 0xc4, 0x90, 0x14, 0xe8, 0x41, 0xd8, 0x7a, 0xa9,
-	0x65, 0xb9, 0x4a, 0x1b, 0x18, 0xb9, 0x14, 0x7c, 0x8b, 0xd3, 0x5d, 0x52, 0x0b, 0x72, 0xf2, 0x2b,
-	0xfd, 0x52, 0xcb, 0x83, 0x73, 0x13, 0x8b, 0x4a, 0x9c, 0xf3, 0xf3, 0x4a, 0x8a, 0x12, 0x93, 0x4b,
-	0x82, 0x52, 0x0b, 0x4b, 0x53, 0x8b, 0x4b, 0x84, 0x24, 0xb8, 0xd8, 0x93, 0x8b, 0x52, 0x13, 0x4b,
-	0xf2, 0x8b, 0x24, 0x18, 0x15, 0x18, 0x35, 0x38, 0x83, 0x60, 0x5c, 0x21, 0x11, 0x2e, 0xd6, 0x92,
-	0xcc, 0x92, 0x9c, 0x54, 0x09, 0x26, 0xb0, 0x38, 0x84, 0x23, 0xa4, 0xc0, 0xc5, 0x9d, 0x92, 0x5a,
-	0x9c, 0x5c, 0x94, 0x59, 0x50, 0x92, 0x99, 0x9f, 0x27, 0xc1, 0x0c, 0x96, 0x43, 0x16, 0x02, 0x99,
-	0x98, 0x98, 0x94, 0xe9, 0x15, 0xec, 0xef, 0x27, 0xc1, 0x02, 0x31, 0x11, 0xca, 0x05, 0xe9, 0x4d,
-	0xaa, 0x2c, 0x49, 0x4d, 0xce, 0x4f, 0x49, 0xf5, 0x48, 0xad, 0x90, 0x60, 0x85, 0xe8, 0x45, 0x12,
-	0x52, 0x52, 0xe0, 0x92, 0xc3, 0xe5, 0xdc, 0xe2, 0x82, 0xfc, 0xbc, 0xe2, 0x54, 0xa3, 0x49, 0x8c,
-	0x5c, 0xcc, 0xbe, 0xc5, 0xe9, 0x42, 0x5d, 0x8c, 0x5c, 0x62, 0xd8, 0x95, 0x0a, 0x59, 0xe8, 0x61,
-	0x0f, 0x10, 0x3d, 0x42, 0x81, 0x21, 0x65, 0x86, 0x4b, 0x27, 0x7e, 0x47, 0x39, 0x39, 0x9f, 0x78,
-	0x24, 0xc7, 0x78, 0xe1, 0x91, 0x1c, 0xe3, 0x83, 0x47, 0x72, 0x8c, 0x13, 0x1e, 0xcb, 0x31, 0x5c,
-	0x78, 0x2c, 0xc7, 0x70, 0xe3, 0xb1, 0x1c, 0x43, 0x94, 0x66, 0x7a, 0x66, 0x49, 0x46, 0x69, 0x92,
-	0x5e, 0x72, 0x7e, 0xae, 0x3e, 0x96, 0x78, 0xac, 0x80, 0xc4, 0x64, 0x65, 0x41, 0x6a, 0x71, 0x12,
-	0x1b, 0x38, 0x36, 0x8d, 0x01, 0x01, 0x00, 0x00, 0xff, 0xff, 0x8c, 0xb6, 0xf9, 0xee, 0xf0, 0x01,
-	0x00, 0x00,
+	// 389 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x53, 0x4d, 0x4b, 0xeb, 0x40,
+	0x14, 0xed, 0xf4, 0xeb, 0xf1, 0xee, 0x5b, 0xbc, 0xc7, 0xf0, 0x28, 0xa1, 0x60, 0x0c, 0x01, 0x69,
+	0x75, 0x91, 0x80, 0x82, 0xb8, 0x11, 0xc1, 0x76, 0x61, 0x85, 0x56, 0x48, 0x77, 0xee, 0x92, 0xf4,
+	0x9a, 0x06, 0x9a, 0x4c, 0xcc, 0x4c, 0x6b, 0xfb, 0x17, 0x5c, 0xb9, 0x73, 0xe9, 0x5f, 0x70, 0xe1,
+	0x8f, 0x70, 0xd9, 0xa5, 0x4b, 0x69, 0xff, 0x88, 0x34, 0xd3, 0x4a, 0xd4, 0x7e, 0xed, 0xe6, 0x9c,
+	0xb9, 0xe7, 0x72, 0xce, 0xbd, 0x5c, 0xd8, 0x8d, 0xec, 0x1e, 0x0b, 0x6c, 0xb7, 0x6b, 0xfb, 0xa1,
+	0x29, 0xdf, 0x26, 0x0e, 0x02, 0x53, 0x0c, 0x8d, 0x28, 0x66, 0x82, 0xd1, 0x52, 0xaa, 0xc0, 0x90,
+	0x6f, 0x03, 0x07, 0x81, 0xfe, 0x4c, 0x40, 0x6b, 0x72, 0xaf, 0x8e, 0x51, 0x8f, 0x8d, 0x5a, 0x78,
+	0xd7, 0x0e, 0xec, 0x58, 0xd4, 0x58, 0x28, 0x62, 0xdb, 0x15, 0x16, 0xde, 0xf6, 0x91, 0x0b, 0xaa,
+	0xc0, 0x2f, 0x37, 0x46, 0x5b, 0xb0, 0x58, 0x21, 0x1a, 0xa9, 0xfe, 0xb6, 0x16, 0x90, 0xfe, 0x87,
+	0x82, 0xf0, 0x45, 0x0f, 0x95, 0x6c, 0xc2, 0x4b, 0x40, 0x35, 0xf8, 0xd3, 0x41, 0xee, 0xc6, 0x7e,
+	0x24, 0x7c, 0x16, 0x2a, 0xb9, 0xe4, 0x2f, 0x4d, 0xcd, 0x3a, 0xda, 0x8e, 0x7f, 0xd9, 0xbe, 0x6a,
+	0x29, 0x79, 0xd9, 0x71, 0x0e, 0x67, 0x5a, 0x67, 0x24, 0xd0, 0x65, 0x1d, 0xbc, 0xc0, 0xa1, 0x52,
+	0x90, 0xda, 0x14, 0xa5, 0x6b, 0xa0, 0xae, 0xb2, 0xcb, 0x23, 0x16, 0x72, 0xd4, 0x1f, 0x09, 0x54,
+	0x9a, 0xdc, 0xb3, 0x30, 0x60, 0x03, 0xfc, 0x52, 0x22, 0x85, 0x01, 0x86, 0x9f, 0xd9, 0x4a, 0x50,
+	0x6c, 0x63, 0xd8, 0xc1, 0x45, 0xb4, 0x39, 0xa2, 0x55, 0xf8, 0xcb, 0xd3, 0xca, 0x46, 0x3d, 0xc9,
+	0x98, 0xb7, 0xbe, 0xd3, 0xf4, 0x00, 0xfe, 0x25, 0x63, 0xb5, 0xf0, 0x06, 0x63, 0x0c, 0x5d, 0x6c,
+	0xd4, 0xe7, 0x91, 0x7f, 0xf0, 0x7a, 0x05, 0xf6, 0x36, 0xb8, 0x92, 0x11, 0x0e, 0x5f, 0xb2, 0x90,
+	0x6b, 0x72, 0x8f, 0xde, 0x13, 0x28, 0x2d, 0x4f, 0x4b, 0x4f, 0x8c, 0xe5, 0x3b, 0x35, 0x36, 0xed,
+	0xb3, 0x7c, 0xbc, 0x4a, 0xb9, 0x7e, 0xae, 0xf4, 0x89, 0xc0, 0xce, 0x5a, 0xfb, 0xf4, 0x6c, 0x8d,
+	0xa7, 0x6d, 0xd6, 0x51, 0x3e, 0x5d, 0xd5, 0x60, 0xab, 0xb1, 0x9d, 0xd7, 0x5e, 0x27, 0x2a, 0x19,
+	0x4f, 0x54, 0xf2, 0x3e, 0x51, 0xc9, 0xc3, 0x54, 0xcd, 0x8c, 0xa7, 0x6a, 0xe6, 0x6d, 0xaa, 0x66,
+	0xae, 0xf7, 0x3d, 0x5f, 0x74, 0xfb, 0x8e, 0xe1, 0xb2, 0xc0, 0x5c, 0x72, 0x2c, 0x43, 0x79, 0x2e,
+	0xa3, 0x08, 0xb9, 0x53, 0x4c, 0x4e, 0xe6, 0xe8, 0x23, 0x00, 0x00, 0xff, 0xff, 0x91, 0x84, 0x7c,
+	0x8e, 0x55, 0x03, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -182,6 +288,7 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MsgClient interface {
 	DeployNewSmartContract(ctx context.Context, in *MsgDeployNewSmartContractRequest, opts ...grpc.CallOption) (*DeployNewSmartContractResponse, error)
+	RemoveSmartContractDeployment(ctx context.Context, in *MsgRemoveSmartContractDeploymentRequest, opts ...grpc.CallOption) (*RemoveSmartContractDeploymentResponse, error)
 }
 
 type msgClient struct {
@@ -201,9 +308,19 @@ func (c *msgClient) DeployNewSmartContract(ctx context.Context, in *MsgDeployNew
 	return out, nil
 }
 
+func (c *msgClient) RemoveSmartContractDeployment(ctx context.Context, in *MsgRemoveSmartContractDeploymentRequest, opts ...grpc.CallOption) (*RemoveSmartContractDeploymentResponse, error) {
+	out := new(RemoveSmartContractDeploymentResponse)
+	err := c.cc.Invoke(ctx, "/palomachain.paloma.evm.Msg/DeleteSmartContractDeployment", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	DeployNewSmartContract(context.Context, *MsgDeployNewSmartContractRequest) (*DeployNewSmartContractResponse, error)
+	RemoveSmartContractDeployment(context.Context, *MsgRemoveSmartContractDeploymentRequest) (*RemoveSmartContractDeploymentResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -212,6 +329,9 @@ type UnimplementedMsgServer struct {
 
 func (*UnimplementedMsgServer) DeployNewSmartContract(ctx context.Context, req *MsgDeployNewSmartContractRequest) (*DeployNewSmartContractResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeployNewSmartContract not implemented")
+}
+func (*UnimplementedMsgServer) RemoveSmartContractDeployment(ctx context.Context, req *MsgRemoveSmartContractDeploymentRequest) (*RemoveSmartContractDeploymentResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteSmartContractDeployment not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -236,6 +356,24 @@ func _Msg_DeployNewSmartContract_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_RemoveSmartContractDeployment_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgRemoveSmartContractDeploymentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).RemoveSmartContractDeployment(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/palomachain.paloma.evm.Msg/DeleteSmartContractDeployment",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).RemoveSmartContractDeployment(ctx, req.(*MsgRemoveSmartContractDeploymentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "palomachain.paloma.evm.Msg",
 	HandlerType: (*MsgServer)(nil),
@@ -243,6 +381,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeployNewSmartContract",
 			Handler:    _Msg_DeployNewSmartContract_Handler,
+		},
+		{
+			MethodName: "DeleteSmartContractDeployment",
+			Handler:    _Msg_RemoveSmartContractDeployment_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -330,6 +472,71 @@ func (m *DeployNewSmartContractResponse) MarshalToSizedBuffer(dAtA []byte) (int,
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgRemoveSmartContractDeploymentRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgRemoveSmartContractDeploymentRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgRemoveSmartContractDeploymentRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.ChainReferenceID) > 0 {
+		i -= len(m.ChainReferenceID)
+		copy(dAtA[i:], m.ChainReferenceID)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.ChainReferenceID)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.SmartContractID != 0 {
+		i = encodeVarintTx(dAtA, i, uint64(m.SmartContractID))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Sender) > 0 {
+		i -= len(m.Sender)
+		copy(dAtA[i:], m.Sender)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Sender)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *RemoveSmartContractDeploymentResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RemoveSmartContractDeploymentResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RemoveSmartContractDeploymentResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -371,6 +578,35 @@ func (m *MsgDeployNewSmartContractRequest) Size() (n int) {
 }
 
 func (m *DeployNewSmartContractResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgRemoveSmartContractDeploymentRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Sender)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	if m.SmartContractID != 0 {
+		n += 1 + sovTx(uint64(m.SmartContractID))
+	}
+	l = len(m.ChainReferenceID)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	return n
+}
+
+func (m *RemoveSmartContractDeploymentResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -622,6 +858,189 @@ func (m *DeployNewSmartContractResponse) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: DeployNewSmartContractResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgRemoveSmartContractDeploymentRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgRemoveSmartContractDeploymentRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgRemoveSmartContractDeploymentRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Sender", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Sender = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SmartContractID", wireType)
+			}
+			m.SmartContractID = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.SmartContractID |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ChainReferenceID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ChainReferenceID = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RemoveSmartContractDeploymentResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RemoveSmartContractDeploymentResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RemoveSmartContractDeploymentResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/610

# Background

Paloma tracks smart contract deployments purely as a caching mechanism to prevent double-deploying too quickly.  We have an edge case where a deployment fails to go through for too long, it will get stuck.  Paloma will think it's deploying, but the message was long since deleted.

Now, we have a way of deleting this stuck deployment.  This is effectively the same as clearing the cache flag, and the chain will trigger a fresh deployment on the next block.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
