### PR TITLE
Increase the number of blocks to keep stale messages

### DIFF
--- a/x/consensus/module.go
+++ b/x/consensus/module.go
@@ -164,8 +164,8 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		am.keeper.Logger(ctx).Error("error while attesting to messages", "err", err)
 	}
 
-	if ctx.BlockHeight()%10 == 0 {
-		err := am.keeper.DeleteOldMessages(ctx, 300)
+	if ctx.BlockHeight()%50 == 0 {
+		err := am.keeper.DeleteOldMessages(ctx, 1200)
 		if err != nil {
 			am.keeper.Logger(ctx).Error("error while deleting old messages", "err", err)
 		}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/630

# Background

We just increase our block speed drastically.  As such, we need to increase the amount of blocks to allow messages to remain stale. This is because we have more blocks per minute.

We also don't need to check quite as often for the same reason.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
