### PR TITLE
Update readme in master for v1.7.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ rm -r ~/.paloma/data/wasm/cache
 ### To get the latest prebuilt `palomad` binary:
 
 ```shell
-wget -O - https://github.com/palomachain/paloma/releases/download/v1.6.1/paloma_Linux_x86_64.tar.gz  | \
+wget -O - https://github.com/palomachain/paloma/releases/download/v1.7.0/paloma_Linux_x86_64.tar.gz  | \
   sudo tar -C /usr/local/bin -xvzf - palomad
 sudo chmod +x /usr/local/bin/palomad
 ```
@@ -87,7 +87,7 @@ sudo chmod +x /usr/local/bin/palomad
 ```shell
 git clone https://github.com/palomachain/paloma.git
 cd paloma
-git checkout v1.6.1
+git checkout v1.7.0
 make build
 sudo mv ./build/palomad /usr/local/bin/palomad
 ```


### PR DESCRIPTION
This needs done after every release.  We released yesterday.

Even though we're about to have a 1.7.1 release, we want the readme to remain at 1.7.0.

1.7.1 will work for cli commands, but it will not work for validators because of the version upgrade checking.