### PR TITLE
fix: validator selection with  multiple MEV chains configured

### DIFF
--- a/x/evm/keeper/msg_assigner.go
+++ b/x/evm/keeper/msg_assigner.go
@@ -24,7 +24,7 @@ func filterAssignableValidators(validators []valsettypes.Validator, chainID stri
 	return slice.Filter(validators, func(val valsettypes.Validator) bool {
 		for _, v := range val.ExternalChainInfos {
 			if v.ChainReferenceID != chainID {
-				return false
+				continue
 			}
 
 			for _, t := range v.Traits {

--- a/x/evm/keeper/msg_assigner_test.go
+++ b/x/evm/keeper/msg_assigner_test.go
@@ -774,6 +774,48 @@ func TestFilterAssignableValidators(t *testing.T) {
 			requirements: &xchain.JobRequirements{EnforceMEVRelay: true},
 			chainID:      chainID,
 		},
+		{
+			name:        "with MEV set as requirement and multiple chains configured - REGRESSION",
+			expectedStr: "should return only validators with MEV trait",
+			validators: []valsettypes.Validator{
+				{
+					Address: sdk.ValAddress("validator-1"),
+				},
+				{
+					Address: sdk.ValAddress("validator-2"),
+					ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+						{
+							ChainReferenceID: "other-chain",
+							Traits:           []string{valsettypes.PIGEON_TRAIT_MEV},
+						},
+						{
+							ChainReferenceID: chainID,
+							Traits:           []string{valsettypes.PIGEON_TRAIT_MEV},
+						},
+					},
+				},
+				{
+					Address: sdk.ValAddress("validator-3"),
+				},
+			},
+			expected: []valsettypes.Validator{
+				{
+					Address: sdk.ValAddress("validator-2"),
+					ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+						{
+							ChainReferenceID: "other-chain",
+							Traits:           []string{valsettypes.PIGEON_TRAIT_MEV},
+						},
+						{
+							ChainReferenceID: chainID,
+							Traits:           []string{valsettypes.PIGEON_TRAIT_MEV},
+						},
+					},
+				},
+			},
+			requirements: &xchain.JobRequirements{EnforceMEVRelay: true},
+			chainID:      chainID,
+		},
 	}
 
 	for k, v := range tests {


### PR DESCRIPTION
This was already tested and merged into master.  We want it in the current release