### PR TITLE
chore: upgrade Pigeon dependency to v1.6.0

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -141,7 +141,7 @@ const (
 
 	wasmAvailableCapabilities = "iterator,staking,stargate,paloma"
 
-	minimumPigeonVersion = "v1.5.0"
+	minimumPigeonVersion = "v1.6.0"
 )
 
 func getGovProposalHandlers() []govclient.ProposalHandler {


### PR DESCRIPTION
Upgrading the minimum required pigeon version to `v1.6.0` 