### PR TITLE
feat: 🔧 prevent jailing high stake validators

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -528,6 +528,7 @@ func New(
 		app.GetSubspace(valsetmoduletypes.ModuleName),
 		app.StakingKeeper,
 		minimumPigeonVersion,
+		sdk.DefaultPowerReduction,
 	)
 
 	consensusRegistry := consensusmodulekeeper.NewRegistry()

--- a/testutil/keeper/valset.go
+++ b/testutil/keeper/valset.go
@@ -44,6 +44,7 @@ func ValsetKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 		paramsSubspace,
 		nil,
 		"v1.4.0",
+		sdk.DefaultPowerReduction,
 	)
 
 	k.EvmKeeper = mocks.NewEvmKeeper(t)

--- a/x/gravity/keeper/keeper.go
+++ b/x/gravity/keeper/keeper.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	sdkmath "cosmossdk.io/math"
 	tmbytes "github.com/cometbft/cometbft/libs/bytes"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -33,7 +34,7 @@ type Keeper struct {
 	bankKeeper             types.BankKeeper
 	SlashingKeeper         types.SlashingKeeper
 	DistributionKeeper     types.DistributionKeeper
-	PowerReduction         sdk.Int
+	PowerReduction         sdkmath.Int
 	hooks                  types.GravityHooks
 	ReceiverModuleAccounts map[string]string
 	SenderModuleAccounts   map[string]string
@@ -49,7 +50,7 @@ func NewKeeper(
 	bankKeeper types.BankKeeper,
 	slashingKeeper types.SlashingKeeper,
 	distributionKeeper types.DistributionKeeper,
-	powerReduction sdk.Int,
+	powerReduction sdkmath.Int,
 	receiverModuleAccounts map[string]string,
 	senderModuleAccounts map[string]string,
 ) Keeper {

--- a/x/valset/keeper/keep_alive_test.go
+++ b/x/valset/keeper/keep_alive_test.go
@@ -19,8 +19,10 @@ func TestJailingInactiveValidators(t *testing.T) {
 	valBuild := func(id int, toBeJailed bool) (*mocks.StakingValidatorI, sdk.ValAddress) {
 		val := sdk.ValAddress(fmt.Sprintf("validator_%d", id))
 		vali := mocks.NewStakingValidatorI(t)
+		stake := sdk.DefaultPowerReduction
 		ms.StakingKeeper.On("Validator", mock.Anything, val).Return(vali)
 		vali.On("IsJailed").Return(false)
+		vali.On("GetConsensusPower", k.powerReduction).Return(stake.Int64())
 		vali.On("IsBonded").Return(true)
 		vali.On("GetOperator").Return(val)
 		vali.On("GetStatus").Return(stakingtypes.Bonded)

--- a/x/valset/keeper/keeper_integration_test.go
+++ b/x/valset/keeper/keeper_integration_test.go
@@ -95,5 +95,19 @@ var _ = Describe("jaling validators", func() {
 				Expect(err).To(MatchError(keeper.ErrValidatorAlreadyJailed))
 			})
 		})
+
+		Context("jailing validator with too much network stake", func() {
+			BeforeEach(func() {
+				By("change validator stake")
+				validators := testutil.GenValidators(1, 100)
+				a.StakingKeeper.SetValidator(ctx, validators[0])
+				a.StakingKeeper.SetValidatorByConsAddr(ctx, validators[0])
+				val = validators[0].GetOperator()
+			})
+			It("returns an error", func() {
+				err := a.ValsetKeeper.Jail(ctx, val, "i am bored")
+				Expect(err).To(MatchError(keeper.ErrCannotJailValidator))
+			})
+		})
 	})
 })

--- a/x/valset/keeper/setup_test.go
+++ b/x/valset/keeper/setup_test.go
@@ -56,6 +56,7 @@ func newValsetKeeper(t testing.TB) (*Keeper, mockedServices, sdk.Context) {
 		paramsSubspace,
 		ms.StakingKeeper,
 		"v1.4.0",
+		sdk.DefaultPowerReduction,
 	)
 
 	k.EvmKeeper = ms.EvmKeeper


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/708

# Background

The only security measurement in place during jailing so far was a check to see that Paloma would not run with less than 1 validator. 

This change adds a new safeguard, making sure that a validator will not be jailed if they're holding 25% or more of the entire network stake.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
