### PR TITLE
tryfix: paloma status update tx parsing failure

### DIFF
--- a/x/paloma/types/codec.go
+++ b/x/paloma/types/codec.go
@@ -3,6 +3,7 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
@@ -11,6 +12,10 @@ func RegisterCodec(cdc *codec.LegacyAmino) {
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgAddStatusUpdate{},
+	)
+
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }
 


### PR DESCRIPTION
It's possible the errors we see in https://github.com/palomachain/paloma/issues/1006 are stemming from the message not getting registered against the interface registry, although I'm still unsure why it works some times and not others.

Testing this in private test net is currently very difficult, with the amount of `account sequence mismatch` leading to chain halts.