### PR TITLE
fix: ease keep-alive duration

### DIFF
--- a/x/valset/keeper/keeper_test.go
+++ b/x/valset/keeper/keeper_test.go
@@ -49,7 +49,7 @@ func TestIfValidatorCanBeAccepted(t *testing.T) {
 
 func TestRegisteringPigeon(t *testing.T) {
 	k, ms, ctx := newValsetKeeper(t)
-	ctx = ctx.WithBlockHeight(1000)
+	ctx = ctx.WithBlockHeight(3000)
 	val := sdk.ValAddress("validator")
 	val2 := sdk.ValAddress("validator2")
 	nonExistingVal := sdk.ValAddress("i dont exist")


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/856

# Background

Increasing the TTL to approx. 50 minutes. Pigeons will start calling in 15 minutes before. This should give enough leeway to allow us to bring back locking and avoid the `account sequence mismatch` error.

# Testing completed

- [x] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
