### PR TITLE
feat: hold SLC until JIT valset update is processed

### DIFF
--- a/x/consensus/keeper/concensus_keeper.go
+++ b/x/consensus/keeper/concensus_keeper.go
@@ -163,7 +163,7 @@ func (k Keeper) GetMessagesForRelaying(ctx sdk.Context, queueTypeName string, va
 
 		// Looks like there is a valset update for the target chain,
 		// only return true if this message is younger than the valset update
-		return msg.GetId() < vuMid
+		return msg.GetId() <= vuMid
 	})
 
 	// Filter down to just messages assigned to this validator

--- a/x/consensus/keeper/concensus_keeper_test.go
+++ b/x/consensus/keeper/concensus_keeper_test.go
@@ -233,7 +233,7 @@ func TestGetMessagesForRelaying(t *testing.T) {
 	require.Len(t, msgs, 1, "validator should get exactly 1 message")
 
 	// update valset message on other chain
-	_, err = k.PutMessageInQueue(ctx, queueWithValsetUpdatesPending, &evmtypes.Message{
+	vuID, err := k.PutMessageInQueue(ctx, queueWithValsetUpdatesPending, &evmtypes.Message{
 		TurnstoneID:      "abc",
 		ChainReferenceID: "pending-chain",
 		Assignee:         val.String(),
@@ -257,8 +257,9 @@ func TestGetMessagesForRelaying(t *testing.T) {
 
 	msgs, err = k.GetMessagesForRelaying(ctx, queueWithValsetUpdatesPending, val)
 	require.NoError(t, err)
-	require.Len(t, msgs, 1, "validator should get exactly 1 message, second message is blocked by valset update")
+	require.Len(t, msgs, 2, "validator should get exactly 2 messages, orig SLC & valset update, last message is blocked by valset update")
 	require.Equal(t, origID, msgs[0].GetId(), "should match ID of first message, not second")
+	require.Equal(t, vuID, msgs[1].GetId(), "should match ID of first message, not second")
 }
 
 func TestGettingMessagesThatHaveReachedConsensus(t *testing.T) {

--- a/x/consensus/keeper/keeper_setup_test.go
+++ b/x/consensus/keeper/keeper_setup_test.go
@@ -14,6 +14,7 @@ import (
 	typesparams "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/palomachain/paloma/x/consensus/types"
 	"github.com/palomachain/paloma/x/consensus/types/mocks"
+	evmtypes "github.com/palomachain/paloma/x/evm/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,6 +38,7 @@ func newConsensusKeeper(t testing.TB) (*Keeper, mockedServices, sdk.Context) {
 	appCodec := codec.NewProtoCodec(registry)
 
 	types.RegisterInterfaces(registry)
+	evmtypes.RegisterInterfaces(registry)
 
 	registry.RegisterImplementations((*types.ConsensusMsg)(nil),
 		&types.SimpleMessage{},


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/855

# Background

This change adds an additional filter when Pigeons ask for any messages for relaying. It will hold off on returning any SLC messages on target chains that have pending valset updates.

This takes care of two race conditions:

- ValsetUpdate & SLC deployed by same Pigeon: replaying of both messages happens VERY quickly in succession -> high risk of `Incorrect Checkpoint` error
- ValsetUpdate & SLC deployed by two different Pigeons: even higher risk, as the SLC might get relayed BEFORE the valset update

With this change, SLC messages will never be given out to Pigeons as long as a previous valset update is still outstanding, meaning there is no way it would get delivered before the valset update or in too close a succession.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
