### PR TITLE
fix: assigning msgs to validators w/o chain support

### DIFF
--- a/x/evm/keeper/msg_assigner.go
+++ b/x/evm/keeper/msg_assigner.go
@@ -17,14 +17,14 @@ type MsgAssigner struct {
 }
 
 func filterAssignableValidators(validators []valsettypes.Validator, chainID string, req *xchain.JobRequirements) []valsettypes.Validator {
-	if req == nil || req.EnforceMEVRelay == false {
-		return validators
-	}
-
 	return slice.Filter(validators, func(val valsettypes.Validator) bool {
 		for _, v := range val.ExternalChainInfos {
 			if v.ChainReferenceID != chainID {
 				continue
+			}
+
+			if req == nil || !req.EnforceMEVRelay {
+				return true
 			}
 
 			for _, t := range v.Traits {

--- a/x/evm/keeper/msg_assigner_test.go
+++ b/x/evm/keeper/msg_assigner_test.go
@@ -550,12 +550,27 @@ func TestPickValidatorForMessage(t *testing.T) {
 					Validators: []valsettypes.Validator{
 						{
 							Address: sdk.ValAddress("testvalidator1"),
+							ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+								{
+									ChainReferenceID: "test-chain",
+								},
+							},
 						},
 						{
 							Address: sdk.ValAddress("testvalidator2"),
+							ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+								{
+									ChainReferenceID: "test-chain",
+								},
+							},
 						},
 						{
 							Address: sdk.ValAddress("testvalidator3"),
+							ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+								{
+									ChainReferenceID: "test-chain",
+								},
+							},
 						},
 					},
 				}
@@ -571,6 +586,7 @@ func TestPickValidatorForMessage(t *testing.T) {
 				Uptime:        "0.5",
 				Fee:           "0.5",
 			},
+			chainID:      "test-chain",
 			expected: sdk.ValAddress("testvalidator1").String(),
 		},
 		{
@@ -617,12 +633,27 @@ func TestPickValidatorForMessage(t *testing.T) {
 					Validators: []valsettypes.Validator{
 						{
 							Address: sdk.ValAddress("testvalidator1"),
+							ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+								{
+									ChainReferenceID: "test-chain",
+								},
+							},
 						},
 						{
 							Address: sdk.ValAddress("testvalidator2"),
+							ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+								{
+									ChainReferenceID: "test-chain",
+								},
+							},
 						},
 						{
 							Address: sdk.ValAddress("testvalidator3"),
+							ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+								{
+									ChainReferenceID: "test-chain",
+								},
+							},
 						},
 					},
 				}
@@ -632,6 +663,7 @@ func TestPickValidatorForMessage(t *testing.T) {
 
 				return msgAssigner
 			},
+			chainID:      "test-chain",
 			expected: sdk.ValAddress("testvalidator1").String(),
 		},
 		{
@@ -648,6 +680,11 @@ func TestPickValidatorForMessage(t *testing.T) {
 					Validators: []valsettypes.Validator{
 						{
 							Address: sdk.ValAddress("testvalidator1"),
+							ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+								{
+									ChainReferenceID: "test-chain",
+								},
+							},
 						},
 						{
 							Address: sdk.ValAddress("testvalidator2"),
@@ -657,6 +694,11 @@ func TestPickValidatorForMessage(t *testing.T) {
 						},
 						{
 							Address: sdk.ValAddress("testvalidator3"),
+							ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+								{
+									ChainReferenceID: "test-chain",
+								},
+							},
 						},
 					},
 				}
@@ -689,8 +731,8 @@ func TestPickValidatorForMessage(t *testing.T) {
 
 			actual, actualErr := messageAssigner.PickValidatorForMessage(ctx, tt.weights, tt.chainID, tt.requirements)
 
-			asserter.Equal(tt.expected, actual)
-			asserter.Equal(tt.expectedErr, actualErr)
+			asserter.Equal(tt.expected, actual, tt.name)
+			asserter.Equal(tt.expectedErr, actualErr, tt.name)
 		})
 	}
 }
@@ -700,12 +742,27 @@ func TestFilterAssignableValidators(t *testing.T) {
 	defaultValidators := []valsettypes.Validator{
 		{
 			Address: sdk.ValAddress("validator-1"),
+			ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+				{
+					ChainReferenceID: "test-chain",
+				},
+			},
 		},
 		{
 			Address: sdk.ValAddress("validator-2"),
+			ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+				{
+					ChainReferenceID: "test-chain",
+				},
+			},
 		},
 		{
 			Address: sdk.ValAddress("validator-3"),
+			ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+				{
+					ChainReferenceID: "test-chain",
+				},
+			},
 		},
 	}
 	tests := []struct {
@@ -720,7 +777,7 @@ func TestFilterAssignableValidators(t *testing.T) {
 			name:         "with empty validator slice",
 			expectedStr:  "should return empty slice",
 			validators:   []valsettypes.Validator{},
-			expected:     []valsettypes.Validator{},
+			expected:     []valsettypes.Validator(nil),
 			requirements: nil,
 			chainID:      chainID,
 		},
@@ -814,6 +871,54 @@ func TestFilterAssignableValidators(t *testing.T) {
 				},
 			},
 			requirements: &xchain.JobRequirements{EnforceMEVRelay: true},
+			chainID:      chainID,
+		},
+		{
+			name:        "with validators not supporting required chain ID",
+			expectedStr: "should remove validators without full chain support from result set",
+			validators: []valsettypes.Validator{
+				{
+					Address: sdk.ValAddress("validator-1"),
+					ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+						{
+							ChainReferenceID: "other-chain",
+						},
+					},
+				},
+				{
+					Address: sdk.ValAddress("validator-2"),
+					ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+						{
+							ChainReferenceID: "other-chain",
+						},
+						{
+							ChainReferenceID: chainID,
+						},
+					},
+				},
+				{
+					Address: sdk.ValAddress("validator-3"),
+					ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+						{
+							ChainReferenceID: "other-chain",
+						},
+					},
+				},
+			},
+			expected: []valsettypes.Validator{
+				{
+					Address: sdk.ValAddress("validator-2"),
+					ExternalChainInfos: []*valsettypes.ExternalChainInfo{
+						{
+							ChainReferenceID: "other-chain",
+						},
+						{
+							ChainReferenceID: chainID,
+						},
+					},
+				},
+			},
+			requirements: nil,
 			chainID:      chainID,
 		},
 	}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/944

# Background

There's a hen & egg situation in case we're currently onboarding a new chain on Paloma, as the chain status is not yet active, Validators without full support for the new chain will still be within the active validator set.

This change adds target chain awareness when filtering for viable message relayers, ensuring that validators with missing chain support for the required target chain are no longer considered.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
