### PR TITLE
fix: gravity message logging format

### DIFF
--- a/x/evm/keeper/msg_assigner_test.go
+++ b/x/evm/keeper/msg_assigner_test.go
@@ -586,7 +586,7 @@ func TestPickValidatorForMessage(t *testing.T) {
 				Uptime:        "0.5",
 				Fee:           "0.5",
 			},
-			chainID:      "test-chain",
+			chainID:  "test-chain",
 			expected: sdk.ValAddress("testvalidator1").String(),
 		},
 		{
@@ -620,7 +620,9 @@ func TestPickValidatorForMessage(t *testing.T) {
 			expectedErr: errors.New("no snapshot found"),
 		},
 		{
-			name: "assigns a consistent pseudo-random validator in the happy path when no weights exist (cold start)",
+			chainID:  "test-chain",
+			expected: sdk.ValAddress("testvalidator1").String(),
+			name:     "assigns a consistent pseudo-random validator in the happy path when no weights exist (cold start)",
 			setup: func() MsgAssigner {
 				msgAssigner := MsgAssigner{}
 
@@ -663,8 +665,6 @@ func TestPickValidatorForMessage(t *testing.T) {
 
 				return msgAssigner
 			},
-			chainID:      "test-chain",
-			expected: sdk.ValAddress("testvalidator1").String(),
 		},
 		{
 			name: "applies validator filtering based on job requirements",

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -157,9 +157,9 @@ func (k msgServer) claimHandlerCommon(ctx sdk.Context, msgAny *codectypes.Any, m
 	// Emit the handle message event
 	return ctx.EventManager().EmitTypedEvent(
 		&types.EventClaim{
-			Message:       string(msg.GetType()),
-			ClaimHash:     string(hash),
-			AttestationId: string(types.GetAttestationKey(msg.GetEventNonce(), hash)),
+			Message:       msg.GetType().String(),
+			ClaimHash:     fmt.Sprintf("%x", hash),
+			AttestationId: fmt.Sprintf("%x", types.GetAttestationKey(msg.GetEventNonce(), hash)),
 		},
 	)
 }


### PR DESCRIPTION
The current logging format is pretty useless and doesn't allow to query for transactions via event predicates. This should help.