### PR TITLE
feat: add query for last observed event nonce

### DIFF
--- a/proto/palomachain/paloma/gravity/query.proto
+++ b/proto/palomachain/paloma/gravity/query.proto
@@ -16,7 +16,8 @@ option go_package = "github.com/palomachain/paloma/x/gravity/types";
 service Query {
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {}
   rpc LastPendingBatchRequestByAddr(QueryLastPendingBatchRequestByAddrRequest) returns (QueryLastPendingBatchRequestByAddrResponse) {}
-  rpc LastEventNonceByAddr(QueryLastEventNonceByAddrRequest) returns (QueryLastEventNonceByAddrResponse) {}
+  rpc LastEventNonce(QueryLastEventNonceRequest) returns (QueryLastEventNonceResponse) {}
+  rpc LastEventNonceByAddr(QueryLastEventNonceByAddrRequest) returns (QueryLastEventNonceResponse) {}
   rpc OutgoingTxBatches(QueryOutgoingTxBatchesRequest) returns (QueryOutgoingTxBatchesResponse) {}
   rpc BatchRequestByNonce(QueryBatchRequestByNonceRequest) returns (QueryBatchRequestByNonceResponse) {}
   rpc BatchConfirms(QueryBatchConfirmsRequest) returns (QueryBatchConfirmsResponse) {}
@@ -67,10 +68,11 @@ message QueryBatchConfirmsResponse {
   repeated MsgConfirmBatch confirms = 1 [(gogoproto.nullable) = false];
 }
 
+message QueryLastEventNonceRequest {}
 message QueryLastEventNonceByAddrRequest {
   string address = 1;
 }
-message QueryLastEventNonceByAddrResponse {
+message QueryLastEventNonceResponse {
   uint64 event_nonce = 1;
 }
 

--- a/x/gravity/types/query.pb.go
+++ b/x/gravity/types/query.pb.go
@@ -6,6 +6,10 @@ package types
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/cosmos/gogoproto/grpc"
 	proto "github.com/cosmos/gogoproto/proto"
@@ -13,15 +17,14 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	io "io"
-	math "math"
-	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -29,8 +32,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-type QueryParamsRequest struct {
-}
+type QueryParamsRequest struct{}
 
 func (m *QueryParamsRequest) Reset()         { *m = QueryParamsRequest{} }
 func (m *QueryParamsRequest) String() string { return proto.CompactTextString(m) }
@@ -38,9 +40,11 @@ func (*QueryParamsRequest) ProtoMessage()    {}
 func (*QueryParamsRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a3b0def5f4d1670a, []int{0}
 }
+
 func (m *QueryParamsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryParamsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryParamsRequest.Marshal(b, m, deterministic)
@@ -53,12 +57,15 @@ func (m *QueryParamsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *QueryParamsRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryParamsRequest.Merge(m, src)
 }
+
 func (m *QueryParamsRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryParamsRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryParamsRequest.DiscardUnknown(m)
 }
@@ -75,9 +82,11 @@ func (*QueryParamsResponse) ProtoMessage()    {}
 func (*QueryParamsResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a3b0def5f4d1670a, []int{1}
 }
+
 func (m *QueryParamsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryParamsResponse.Marshal(b, m, deterministic)
@@ -90,12 +99,15 @@ func (m *QueryParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
+
 func (m *QueryParamsResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryParamsResponse.Merge(m, src)
 }
+
 func (m *QueryParamsResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryParamsResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryParamsResponse.DiscardUnknown(m)
 }
@@ -116,6 +128,7 @@ type QueryLastPendingBatchRequestByAddrRequest struct {
 func (m *QueryLastPendingBatchRequestByAddrRequest) Reset() {
 	*m = QueryLastPendingBatchRequestByAddrRequest{}
 }
+
 func (m *QueryLastPendingBatchRequestByAddrRequest) String() string {
 	return proto.CompactTextString(m)
 }
@@ -123,9 +136,11 @@ func (*QueryLastPendingBatchRequestByAddrRequest) ProtoMessage() {}
 func (*QueryLastPendingBatchRequestByAddrRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a3b0def5f4d1670a, []int{2}
 }
+
 func (m *QueryLastPendingBatchRequestByAddrRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryLastPendingBatchRequestByAddrRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryLastPendingBatchRequestByAddrRequest.Marshal(b, m, deterministic)
@@ -138,12 +153,15 @@ func (m *QueryLastPendingBatchRequestByAddrRequest) XXX_Marshal(b []byte, determ
 		return b[:n], nil
 	}
 }
+
 func (m *QueryLastPendingBatchRequestByAddrRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryLastPendingBatchRequestByAddrRequest.Merge(m, src)
 }
+
 func (m *QueryLastPendingBatchRequestByAddrRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryLastPendingBatchRequestByAddrRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryLastPendingBatchRequestByAddrRequest.DiscardUnknown(m)
 }
@@ -164,6 +182,7 @@ type QueryLastPendingBatchRequestByAddrResponse struct {
 func (m *QueryLastPendingBatchRequestByAddrResponse) Reset() {
 	*m = QueryLastPendingBatchRequestByAddrResponse{}
 }
+
 func (m *QueryLastPendingBatchRequestByAddrResponse) String() string {
 	return proto.CompactTextString(m)
 }
@@ -171,9 +190,11 @@ func (*QueryLastPendingBatchRequestByAddrResponse) ProtoMessage() {}
 func (*QueryLastPendingBatchRequestByAddrResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a3b0def5f4d1670a, []int{3}
 }
+
 func (m *QueryLastPendingBatchRequestByAddrResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryLastPendingBatchRequestByAddrResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryLastPendingBatchRequestByAddrResponse.Marshal(b, m, deterministic)
@@ -186,12 +207,15 @@ func (m *QueryLastPendingBatchRequestByAddrResponse) XXX_Marshal(b []byte, deter
 		return b[:n], nil
 	}
 }
+
 func (m *QueryLastPendingBatchRequestByAddrResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryLastPendingBatchRequestByAddrResponse.Merge(m, src)
 }
+
 func (m *QueryLastPendingBatchRequestByAddrResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryLastPendingBatchRequestByAddrResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryLastPendingBatchRequestByAddrResponse.DiscardUnknown(m)
 }
@@ -216,9 +240,11 @@ func (*QueryOutgoingTxBatchesRequest) ProtoMessage()    {}
 func (*QueryOutgoingTxBatchesRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a3b0def5f4d1670a, []int{4}
 }
+
 func (m *QueryOutgoingTxBatchesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryOutgoingTxBatchesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryOutgoingTxBatchesRequest.Marshal(b, m, deterministic)
@@ -231,12 +257,15 @@ func (m *QueryOutgoingTxBatchesRequest) XXX_Marshal(b []byte, deterministic bool
 		return b[:n], nil
 	}
 }
+
 func (m *QueryOutgoingTxBatchesRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryOutgoingTxBatchesRequest.Merge(m, src)
 }
+
 func (m *QueryOutgoingTxBatchesRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryOutgoingTxBatchesRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryOutgoingTxBatchesRequest.DiscardUnknown(m)
 }
@@ -267,9 +296,11 @@ func (*QueryOutgoingTxBatchesResponse) ProtoMessage()    {}
 func (*QueryOutgoingTxBatchesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a3b0def5f4d1670a, []int{5}
 }
+
 func (m *QueryOutgoingTxBatchesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryOutgoingTxBatchesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryOutgoingTxBatchesResponse.Marshal(b, m, deterministic)
@@ -282,12 +313,15 @@ func (m *QueryOutgoingTxBatchesResponse) XXX_Marshal(b []byte, deterministic boo
 		return b[:n], nil
 	}
 }
+
 func (m *QueryOutgoingTxBatchesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryOutgoingTxBatchesResponse.Merge(m, src)
 }
+
 func (m *QueryOutgoingTxBatchesResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryOutgoingTxBatchesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryOutgoingTxBatchesResponse.DiscardUnknown(m)
 }
@@ -312,9 +346,11 @@ func (*QueryBatchRequestByNonceRequest) ProtoMessage()    {}
 func (*QueryBatchRequestByNonceRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a3b0def5f4d1670a, []int{6}
 }
+
 func (m *QueryBatchRequestByNonceRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryBatchRequestByNonceRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryBatchRequestByNonceRequest.Marshal(b, m, deterministic)
@@ -327,12 +363,15 @@ func (m *QueryBatchRequestByNonceRequest) XXX_Marshal(b []byte, deterministic bo
 		return b[:n], nil
 	}
 }
+
 func (m *QueryBatchRequestByNonceRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryBatchRequestByNonceRequest.Merge(m, src)
 }
+
 func (m *QueryBatchRequestByNonceRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryBatchRequestByNonceRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryBatchRequestByNonceRequest.DiscardUnknown(m)
 }
@@ -363,9 +402,11 @@ func (*QueryBatchRequestByNonceResponse) ProtoMessage()    {}
 func (*QueryBatchRequestByNonceResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a3b0def5f4d1670a, []int{7}
 }
+
 func (m *QueryBatchRequestByNonceResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryBatchRequestByNonceResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryBatchRequestByNonceResponse.Marshal(b, m, deterministic)
@@ -378,12 +419,15 @@ func (m *QueryBatchRequestByNonceResponse) XXX_Marshal(b []byte, deterministic b
 		return b[:n], nil
 	}
 }
+
 func (m *QueryBatchRequestByNonceResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryBatchRequestByNonceResponse.Merge(m, src)
 }
+
 func (m *QueryBatchRequestByNonceResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryBatchRequestByNonceResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryBatchRequestByNonceResponse.DiscardUnknown(m)
 }
@@ -408,9 +452,11 @@ func (*QueryBatchConfirmsRequest) ProtoMessage()    {}
 func (*QueryBatchConfirmsRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a3b0def5f4d1670a, []int{8}
 }
+
 func (m *QueryBatchConfirmsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryBatchConfirmsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryBatchConfirmsRequest.Marshal(b, m, deterministic)
@@ -423,12 +469,15 @@ func (m *QueryBatchConfirmsRequest) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
+
 func (m *QueryBatchConfirmsRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryBatchConfirmsRequest.Merge(m, src)
 }
+
 func (m *QueryBatchConfirmsRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryBatchConfirmsRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryBatchConfirmsRequest.DiscardUnknown(m)
 }
@@ -459,9 +508,11 @@ func (*QueryBatchConfirmsResponse) ProtoMessage()    {}
 func (*QueryBatchConfirmsResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a3b0def5f4d1670a, []int{9}
 }
+
 func (m *QueryBatchConfirmsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryBatchConfirmsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryBatchConfirmsResponse.Marshal(b, m, deterministic)
@@ -474,12 +525,15 @@ func (m *QueryBatchConfirmsResponse) XXX_Marshal(b []byte, deterministic bool) (
 		return b[:n], nil
 	}
 }
+
 func (m *QueryBatchConfirmsResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryBatchConfirmsResponse.Merge(m, src)
 }
+
 func (m *QueryBatchConfirmsResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryBatchConfirmsResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryBatchConfirmsResponse.DiscardUnknown(m)
 }
@@ -493,6 +547,46 @@ func (m *QueryBatchConfirmsResponse) GetConfirms() []MsgConfirmBatch {
 	return nil
 }
 
+type QueryLastEventNonceRequest struct{}
+
+func (m *QueryLastEventNonceRequest) Reset()         { *m = QueryLastEventNonceRequest{} }
+func (m *QueryLastEventNonceRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryLastEventNonceRequest) ProtoMessage()    {}
+func (*QueryLastEventNonceRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_a3b0def5f4d1670a, []int{10}
+}
+
+func (m *QueryLastEventNonceRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+
+func (m *QueryLastEventNonceRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryLastEventNonceRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+
+func (m *QueryLastEventNonceRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryLastEventNonceRequest.Merge(m, src)
+}
+
+func (m *QueryLastEventNonceRequest) XXX_Size() int {
+	return m.Size()
+}
+
+func (m *QueryLastEventNonceRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryLastEventNonceRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryLastEventNonceRequest proto.InternalMessageInfo
+
 type QueryLastEventNonceByAddrRequest struct {
 	Address string `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
 }
@@ -501,11 +595,13 @@ func (m *QueryLastEventNonceByAddrRequest) Reset()         { *m = QueryLastEvent
 func (m *QueryLastEventNonceByAddrRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryLastEventNonceByAddrRequest) ProtoMessage()    {}
 func (*QueryLastEventNonceByAddrRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{10}
+	return fileDescriptor_a3b0def5f4d1670a, []int{11}
 }
+
 func (m *QueryLastEventNonceByAddrRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryLastEventNonceByAddrRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryLastEventNonceByAddrRequest.Marshal(b, m, deterministic)
@@ -518,12 +614,15 @@ func (m *QueryLastEventNonceByAddrRequest) XXX_Marshal(b []byte, deterministic b
 		return b[:n], nil
 	}
 }
+
 func (m *QueryLastEventNonceByAddrRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryLastEventNonceByAddrRequest.Merge(m, src)
 }
+
 func (m *QueryLastEventNonceByAddrRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryLastEventNonceByAddrRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryLastEventNonceByAddrRequest.DiscardUnknown(m)
 }
@@ -537,22 +636,24 @@ func (m *QueryLastEventNonceByAddrRequest) GetAddress() string {
 	return ""
 }
 
-type QueryLastEventNonceByAddrResponse struct {
+type QueryLastEventNonceResponse struct {
 	EventNonce uint64 `protobuf:"varint,1,opt,name=event_nonce,json=eventNonce,proto3" json:"event_nonce,omitempty"`
 }
 
-func (m *QueryLastEventNonceByAddrResponse) Reset()         { *m = QueryLastEventNonceByAddrResponse{} }
-func (m *QueryLastEventNonceByAddrResponse) String() string { return proto.CompactTextString(m) }
-func (*QueryLastEventNonceByAddrResponse) ProtoMessage()    {}
-func (*QueryLastEventNonceByAddrResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{11}
+func (m *QueryLastEventNonceResponse) Reset()         { *m = QueryLastEventNonceResponse{} }
+func (m *QueryLastEventNonceResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryLastEventNonceResponse) ProtoMessage()    {}
+func (*QueryLastEventNonceResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_a3b0def5f4d1670a, []int{12}
 }
-func (m *QueryLastEventNonceByAddrResponse) XXX_Unmarshal(b []byte) error {
+
+func (m *QueryLastEventNonceResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *QueryLastEventNonceByAddrResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+
+func (m *QueryLastEventNonceResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_QueryLastEventNonceByAddrResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_QueryLastEventNonceResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -562,19 +663,22 @@ func (m *QueryLastEventNonceByAddrResponse) XXX_Marshal(b []byte, deterministic 
 		return b[:n], nil
 	}
 }
-func (m *QueryLastEventNonceByAddrResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_QueryLastEventNonceByAddrResponse.Merge(m, src)
+
+func (m *QueryLastEventNonceResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryLastEventNonceResponse.Merge(m, src)
 }
-func (m *QueryLastEventNonceByAddrResponse) XXX_Size() int {
+
+func (m *QueryLastEventNonceResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *QueryLastEventNonceByAddrResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_QueryLastEventNonceByAddrResponse.DiscardUnknown(m)
+
+func (m *QueryLastEventNonceResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryLastEventNonceResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_QueryLastEventNonceByAddrResponse proto.InternalMessageInfo
+var xxx_messageInfo_QueryLastEventNonceResponse proto.InternalMessageInfo
 
-func (m *QueryLastEventNonceByAddrResponse) GetEventNonce() uint64 {
+func (m *QueryLastEventNonceResponse) GetEventNonce() uint64 {
 	if m != nil {
 		return m.EventNonce
 	}
@@ -590,11 +694,13 @@ func (m *QueryERC20ToDenomRequest) Reset()         { *m = QueryERC20ToDenomReque
 func (m *QueryERC20ToDenomRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryERC20ToDenomRequest) ProtoMessage()    {}
 func (*QueryERC20ToDenomRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{12}
+	return fileDescriptor_a3b0def5f4d1670a, []int{13}
 }
+
 func (m *QueryERC20ToDenomRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryERC20ToDenomRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryERC20ToDenomRequest.Marshal(b, m, deterministic)
@@ -607,12 +713,15 @@ func (m *QueryERC20ToDenomRequest) XXX_Marshal(b []byte, deterministic bool) ([]
 		return b[:n], nil
 	}
 }
+
 func (m *QueryERC20ToDenomRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryERC20ToDenomRequest.Merge(m, src)
 }
+
 func (m *QueryERC20ToDenomRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryERC20ToDenomRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryERC20ToDenomRequest.DiscardUnknown(m)
 }
@@ -641,11 +750,13 @@ func (m *QueryERC20ToDenomResponse) Reset()         { *m = QueryERC20ToDenomResp
 func (m *QueryERC20ToDenomResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryERC20ToDenomResponse) ProtoMessage()    {}
 func (*QueryERC20ToDenomResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{13}
+	return fileDescriptor_a3b0def5f4d1670a, []int{14}
 }
+
 func (m *QueryERC20ToDenomResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryERC20ToDenomResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryERC20ToDenomResponse.Marshal(b, m, deterministic)
@@ -658,12 +769,15 @@ func (m *QueryERC20ToDenomResponse) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
+
 func (m *QueryERC20ToDenomResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryERC20ToDenomResponse.Merge(m, src)
 }
+
 func (m *QueryERC20ToDenomResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryERC20ToDenomResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryERC20ToDenomResponse.DiscardUnknown(m)
 }
@@ -686,11 +800,13 @@ func (m *QueryDenomToERC20Request) Reset()         { *m = QueryDenomToERC20Reque
 func (m *QueryDenomToERC20Request) String() string { return proto.CompactTextString(m) }
 func (*QueryDenomToERC20Request) ProtoMessage()    {}
 func (*QueryDenomToERC20Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{14}
+	return fileDescriptor_a3b0def5f4d1670a, []int{15}
 }
+
 func (m *QueryDenomToERC20Request) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryDenomToERC20Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryDenomToERC20Request.Marshal(b, m, deterministic)
@@ -703,12 +819,15 @@ func (m *QueryDenomToERC20Request) XXX_Marshal(b []byte, deterministic bool) ([]
 		return b[:n], nil
 	}
 }
+
 func (m *QueryDenomToERC20Request) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryDenomToERC20Request.Merge(m, src)
 }
+
 func (m *QueryDenomToERC20Request) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryDenomToERC20Request) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryDenomToERC20Request.DiscardUnknown(m)
 }
@@ -737,11 +856,13 @@ func (m *QueryDenomToERC20Response) Reset()         { *m = QueryDenomToERC20Resp
 func (m *QueryDenomToERC20Response) String() string { return proto.CompactTextString(m) }
 func (*QueryDenomToERC20Response) ProtoMessage()    {}
 func (*QueryDenomToERC20Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{15}
+	return fileDescriptor_a3b0def5f4d1670a, []int{16}
 }
+
 func (m *QueryDenomToERC20Response) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryDenomToERC20Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryDenomToERC20Response.Marshal(b, m, deterministic)
@@ -754,12 +875,15 @@ func (m *QueryDenomToERC20Response) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
+
 func (m *QueryDenomToERC20Response) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryDenomToERC20Response.Merge(m, src)
 }
+
 func (m *QueryDenomToERC20Response) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryDenomToERC20Response) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryDenomToERC20Response.DiscardUnknown(m)
 }
@@ -787,11 +911,13 @@ func (m *QueryLastObservedEthBlockRequest) Reset()         { *m = QueryLastObser
 func (m *QueryLastObservedEthBlockRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryLastObservedEthBlockRequest) ProtoMessage()    {}
 func (*QueryLastObservedEthBlockRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{16}
+	return fileDescriptor_a3b0def5f4d1670a, []int{17}
 }
+
 func (m *QueryLastObservedEthBlockRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryLastObservedEthBlockRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryLastObservedEthBlockRequest.Marshal(b, m, deterministic)
@@ -804,12 +930,15 @@ func (m *QueryLastObservedEthBlockRequest) XXX_Marshal(b []byte, deterministic b
 		return b[:n], nil
 	}
 }
+
 func (m *QueryLastObservedEthBlockRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryLastObservedEthBlockRequest.Merge(m, src)
 }
+
 func (m *QueryLastObservedEthBlockRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryLastObservedEthBlockRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryLastObservedEthBlockRequest.DiscardUnknown(m)
 }
@@ -833,11 +962,13 @@ func (m *QueryLastObservedEthBlockResponse) Reset()         { *m = QueryLastObse
 func (m *QueryLastObservedEthBlockResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryLastObservedEthBlockResponse) ProtoMessage()    {}
 func (*QueryLastObservedEthBlockResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{17}
+	return fileDescriptor_a3b0def5f4d1670a, []int{18}
 }
+
 func (m *QueryLastObservedEthBlockResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryLastObservedEthBlockResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryLastObservedEthBlockResponse.Marshal(b, m, deterministic)
@@ -850,12 +981,15 @@ func (m *QueryLastObservedEthBlockResponse) XXX_Marshal(b []byte, deterministic 
 		return b[:n], nil
 	}
 }
+
 func (m *QueryLastObservedEthBlockResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryLastObservedEthBlockResponse.Merge(m, src)
 }
+
 func (m *QueryLastObservedEthBlockResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryLastObservedEthBlockResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryLastObservedEthBlockResponse.DiscardUnknown(m)
 }
@@ -883,11 +1017,13 @@ func (m *QueryLastObservedEthNonceRequest) Reset()         { *m = QueryLastObser
 func (m *QueryLastObservedEthNonceRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryLastObservedEthNonceRequest) ProtoMessage()    {}
 func (*QueryLastObservedEthNonceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{18}
+	return fileDescriptor_a3b0def5f4d1670a, []int{19}
 }
+
 func (m *QueryLastObservedEthNonceRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryLastObservedEthNonceRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryLastObservedEthNonceRequest.Marshal(b, m, deterministic)
@@ -900,12 +1036,15 @@ func (m *QueryLastObservedEthNonceRequest) XXX_Marshal(b []byte, deterministic b
 		return b[:n], nil
 	}
 }
+
 func (m *QueryLastObservedEthNonceRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryLastObservedEthNonceRequest.Merge(m, src)
 }
+
 func (m *QueryLastObservedEthNonceRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryLastObservedEthNonceRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryLastObservedEthNonceRequest.DiscardUnknown(m)
 }
@@ -929,11 +1068,13 @@ func (m *QueryLastObservedEthNonceResponse) Reset()         { *m = QueryLastObse
 func (m *QueryLastObservedEthNonceResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryLastObservedEthNonceResponse) ProtoMessage()    {}
 func (*QueryLastObservedEthNonceResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{19}
+	return fileDescriptor_a3b0def5f4d1670a, []int{20}
 }
+
 func (m *QueryLastObservedEthNonceResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryLastObservedEthNonceResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryLastObservedEthNonceResponse.Marshal(b, m, deterministic)
@@ -946,12 +1087,15 @@ func (m *QueryLastObservedEthNonceResponse) XXX_Marshal(b []byte, deterministic 
 		return b[:n], nil
 	}
 }
+
 func (m *QueryLastObservedEthNonceResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryLastObservedEthNonceResponse.Merge(m, src)
 }
+
 func (m *QueryLastObservedEthNonceResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryLastObservedEthNonceResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryLastObservedEthNonceResponse.DiscardUnknown(m)
 }
@@ -994,11 +1138,13 @@ func (m *QueryAttestationsRequest) Reset()         { *m = QueryAttestationsReque
 func (m *QueryAttestationsRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryAttestationsRequest) ProtoMessage()    {}
 func (*QueryAttestationsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{20}
+	return fileDescriptor_a3b0def5f4d1670a, []int{21}
 }
+
 func (m *QueryAttestationsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryAttestationsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryAttestationsRequest.Marshal(b, m, deterministic)
@@ -1011,12 +1157,15 @@ func (m *QueryAttestationsRequest) XXX_Marshal(b []byte, deterministic bool) ([]
 		return b[:n], nil
 	}
 }
+
 func (m *QueryAttestationsRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryAttestationsRequest.Merge(m, src)
 }
+
 func (m *QueryAttestationsRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryAttestationsRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryAttestationsRequest.DiscardUnknown(m)
 }
@@ -1073,11 +1222,13 @@ func (m *QueryAttestationsResponse) Reset()         { *m = QueryAttestationsResp
 func (m *QueryAttestationsResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryAttestationsResponse) ProtoMessage()    {}
 func (*QueryAttestationsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{21}
+	return fileDescriptor_a3b0def5f4d1670a, []int{22}
 }
+
 func (m *QueryAttestationsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryAttestationsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryAttestationsResponse.Marshal(b, m, deterministic)
@@ -1090,12 +1241,15 @@ func (m *QueryAttestationsResponse) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
+
 func (m *QueryAttestationsResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryAttestationsResponse.Merge(m, src)
 }
+
 func (m *QueryAttestationsResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryAttestationsResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryAttestationsResponse.DiscardUnknown(m)
 }
@@ -1109,18 +1263,19 @@ func (m *QueryAttestationsResponse) GetAttestations() []Attestation {
 	return nil
 }
 
-type QueryErc20ToDenoms struct {
-}
+type QueryErc20ToDenoms struct{}
 
 func (m *QueryErc20ToDenoms) Reset()         { *m = QueryErc20ToDenoms{} }
 func (m *QueryErc20ToDenoms) String() string { return proto.CompactTextString(m) }
 func (*QueryErc20ToDenoms) ProtoMessage()    {}
 func (*QueryErc20ToDenoms) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{22}
+	return fileDescriptor_a3b0def5f4d1670a, []int{23}
 }
+
 func (m *QueryErc20ToDenoms) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryErc20ToDenoms) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryErc20ToDenoms.Marshal(b, m, deterministic)
@@ -1133,12 +1288,15 @@ func (m *QueryErc20ToDenoms) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *QueryErc20ToDenoms) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryErc20ToDenoms.Merge(m, src)
 }
+
 func (m *QueryErc20ToDenoms) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryErc20ToDenoms) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryErc20ToDenoms.DiscardUnknown(m)
 }
@@ -1153,11 +1311,13 @@ func (m *QueryErc20ToDenomsResponse) Reset()         { *m = QueryErc20ToDenomsRe
 func (m *QueryErc20ToDenomsResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryErc20ToDenomsResponse) ProtoMessage()    {}
 func (*QueryErc20ToDenomsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{23}
+	return fileDescriptor_a3b0def5f4d1670a, []int{24}
 }
+
 func (m *QueryErc20ToDenomsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryErc20ToDenomsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryErc20ToDenomsResponse.Marshal(b, m, deterministic)
@@ -1170,12 +1330,15 @@ func (m *QueryErc20ToDenomsResponse) XXX_Marshal(b []byte, deterministic bool) (
 		return b[:n], nil
 	}
 }
+
 func (m *QueryErc20ToDenomsResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryErc20ToDenomsResponse.Merge(m, src)
 }
+
 func (m *QueryErc20ToDenomsResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryErc20ToDenomsResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryErc20ToDenomsResponse.DiscardUnknown(m)
 }
@@ -1197,11 +1360,13 @@ func (m *QueryPendingSendToEth) Reset()         { *m = QueryPendingSendToEth{} }
 func (m *QueryPendingSendToEth) String() string { return proto.CompactTextString(m) }
 func (*QueryPendingSendToEth) ProtoMessage()    {}
 func (*QueryPendingSendToEth) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{24}
+	return fileDescriptor_a3b0def5f4d1670a, []int{25}
 }
+
 func (m *QueryPendingSendToEth) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryPendingSendToEth) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryPendingSendToEth.Marshal(b, m, deterministic)
@@ -1214,12 +1379,15 @@ func (m *QueryPendingSendToEth) XXX_Marshal(b []byte, deterministic bool) ([]byt
 		return b[:n], nil
 	}
 }
+
 func (m *QueryPendingSendToEth) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryPendingSendToEth.Merge(m, src)
 }
+
 func (m *QueryPendingSendToEth) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryPendingSendToEth) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryPendingSendToEth.DiscardUnknown(m)
 }
@@ -1242,11 +1410,13 @@ func (m *QueryPendingSendToEthResponse) Reset()         { *m = QueryPendingSendT
 func (m *QueryPendingSendToEthResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryPendingSendToEthResponse) ProtoMessage()    {}
 func (*QueryPendingSendToEthResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a3b0def5f4d1670a, []int{25}
+	return fileDescriptor_a3b0def5f4d1670a, []int{26}
 }
+
 func (m *QueryPendingSendToEthResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryPendingSendToEthResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryPendingSendToEthResponse.Marshal(b, m, deterministic)
@@ -1259,12 +1429,15 @@ func (m *QueryPendingSendToEthResponse) XXX_Marshal(b []byte, deterministic bool
 		return b[:n], nil
 	}
 }
+
 func (m *QueryPendingSendToEthResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryPendingSendToEthResponse.Merge(m, src)
 }
+
 func (m *QueryPendingSendToEthResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryPendingSendToEthResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryPendingSendToEthResponse.DiscardUnknown(m)
 }
@@ -1296,8 +1469,9 @@ func init() {
 	proto.RegisterType((*QueryBatchRequestByNonceResponse)(nil), "palomachain.paloma.gravity.QueryBatchRequestByNonceResponse")
 	proto.RegisterType((*QueryBatchConfirmsRequest)(nil), "palomachain.paloma.gravity.QueryBatchConfirmsRequest")
 	proto.RegisterType((*QueryBatchConfirmsResponse)(nil), "palomachain.paloma.gravity.QueryBatchConfirmsResponse")
+	proto.RegisterType((*QueryLastEventNonceRequest)(nil), "palomachain.paloma.gravity.QueryLastEventNonceRequest")
 	proto.RegisterType((*QueryLastEventNonceByAddrRequest)(nil), "palomachain.paloma.gravity.QueryLastEventNonceByAddrRequest")
-	proto.RegisterType((*QueryLastEventNonceByAddrResponse)(nil), "palomachain.paloma.gravity.QueryLastEventNonceByAddrResponse")
+	proto.RegisterType((*QueryLastEventNonceResponse)(nil), "palomachain.paloma.gravity.QueryLastEventNonceResponse")
 	proto.RegisterType((*QueryERC20ToDenomRequest)(nil), "palomachain.paloma.gravity.QueryERC20ToDenomRequest")
 	proto.RegisterType((*QueryERC20ToDenomResponse)(nil), "palomachain.paloma.gravity.QueryERC20ToDenomResponse")
 	proto.RegisterType((*QueryDenomToERC20Request)(nil), "palomachain.paloma.gravity.QueryDenomToERC20Request")
@@ -1319,87 +1493,90 @@ func init() {
 }
 
 var fileDescriptor_a3b0def5f4d1670a = []byte{
-	// 1193 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x58, 0xcf, 0x6f, 0x1b, 0xc5,
-	0x17, 0xf7, 0xa6, 0xf9, 0xd5, 0x97, 0x36, 0xcd, 0x77, 0xe2, 0x2f, 0xb8, 0xab, 0xc6, 0x09, 0x2b,
-	0x15, 0x52, 0x28, 0x76, 0x13, 0x28, 0x52, 0x20, 0x45, 0x8d, 0x5b, 0x63, 0x55, 0xa5, 0xb4, 0x35,
-	0x16, 0x48, 0x08, 0xb1, 0x5a, 0xef, 0x4e, 0xd6, 0xab, 0xd8, 0x33, 0xee, 0xce, 0x38, 0x8a, 0x25,
-	0x90, 0xb8, 0x70, 0xe3, 0x80, 0x90, 0x90, 0xb8, 0xf3, 0x0f, 0x70, 0xe2, 0x6f, 0xe8, 0xb1, 0x47,
-	0x4e, 0x08, 0x25, 0x77, 0xfe, 0x06, 0xb4, 0xb3, 0xb3, 0xeb, 0x5d, 0x7b, 0x77, 0xbd, 0x71, 0xb8,
-	0xed, 0xbc, 0x79, 0xef, 0xf3, 0x3e, 0x6f, 0xde, 0xbc, 0x79, 0x4f, 0x0b, 0x6f, 0xf6, 0x8d, 0x2e,
-	0xed, 0x19, 0x66, 0xc7, 0x70, 0x48, 0xd5, 0xff, 0xae, 0xda, 0xae, 0x71, 0xec, 0xf0, 0x61, 0xf5,
-	0xc5, 0x00, 0xbb, 0xc3, 0x4a, 0xdf, 0xa5, 0x9c, 0x22, 0x35, 0xa2, 0x57, 0xf1, 0xbf, 0x2b, 0x52,
-	0x4f, 0xbd, 0x99, 0x81, 0xd1, 0xa7, 0xb4, 0xeb, 0x43, 0xa8, 0x59, 0xae, 0xda, 0x06, 0x37, 0x3b,
-	0x52, 0xef, 0x76, 0x86, 0x9e, 0xc1, 0x39, 0x66, 0xdc, 0xe0, 0x0e, 0x25, 0x52, 0xbb, 0x68, 0x53,
-	0x9b, 0x8a, 0xcf, 0xaa, 0xf7, 0x25, 0xa5, 0x37, 0x6c, 0x4a, 0xed, 0x2e, 0xae, 0x1a, 0x7d, 0xa7,
-	0x6a, 0x10, 0x42, 0x7d, 0x13, 0x26, 0x77, 0xb7, 0x33, 0x3c, 0xd8, 0x98, 0x60, 0xe6, 0xb0, 0x1c,
-	0x9c, 0xf9, 0xb0, 0x8f, 0x03, 0xbd, 0xac, 0x23, 0xe8, 0x31, 0x5b, 0xaa, 0x69, 0x45, 0x40, 0xcf,
-	0xbd, 0x43, 0x7d, 0x66, 0xb8, 0x46, 0x8f, 0x35, 0xf1, 0x8b, 0x01, 0x66, 0x5c, 0xfb, 0x12, 0xd6,
-	0x63, 0x52, 0xd6, 0xa7, 0x84, 0x61, 0x74, 0x1f, 0x16, 0xfb, 0x42, 0x52, 0x52, 0xb6, 0x94, 0xed,
-	0x95, 0x5d, 0xad, 0x92, 0x9e, 0x83, 0x8a, 0x6f, 0x5b, 0x9b, 0x7f, 0xf9, 0xd7, 0x66, 0xa1, 0x29,
-	0xed, 0xb4, 0x3a, 0xdc, 0x12, 0xc0, 0x9f, 0x1a, 0x8c, 0x3f, 0xc3, 0xc4, 0x72, 0x88, 0x5d, 0xf3,
-	0x0e, 0x5a, 0x3a, 0xae, 0x0d, 0x0f, 0x2c, 0xcb, 0x95, 0x0b, 0x54, 0x82, 0x25, 0xc3, 0xb2, 0x5c,
-	0xcc, 0x7c, 0x7f, 0x97, 0x9b, 0xc1, 0x52, 0x1b, 0xc0, 0xdb, 0x79, 0x60, 0x24, 0xed, 0x06, 0x2c,
-	0x88, 0x6c, 0x96, 0x94, 0xad, 0x4b, 0xdb, 0x2b, 0xbb, 0xef, 0x64, 0xb1, 0x7e, 0x3a, 0xe0, 0x36,
-	0x75, 0x88, 0xdd, 0x3a, 0x11, 0x80, 0x92, 0xbe, 0x6f, 0xaf, 0x39, 0xb0, 0x21, 0xdc, 0x8e, 0x29,
-	0xe1, 0xe0, 0xdc, 0xd0, 0x6d, 0x40, 0x02, 0x55, 0x77, 0xf1, 0x21, 0x76, 0x31, 0x31, 0xb1, 0xee,
-	0x58, 0x92, 0xfc, 0x9a, 0xd8, 0x69, 0x06, 0x1b, 0x8f, 0x2c, 0xa4, 0xc2, 0xb2, 0xc1, 0x98, 0x63,
-	0x13, 0x8c, 0x4b, 0x73, 0x42, 0x27, 0x5c, 0x6b, 0x3d, 0x28, 0xa7, 0xb9, 0x92, 0x51, 0x3d, 0x86,
-	0xa5, 0xb6, 0x2f, 0x9a, 0x3d, 0xae, 0x00, 0x41, 0x6b, 0xc3, 0xa6, 0x70, 0x17, 0x3f, 0xc5, 0xcf,
-	0x28, 0x31, 0x71, 0x10, 0x5b, 0x11, 0x16, 0x88, 0xb7, 0x16, 0xe1, 0xcc, 0x37, 0xfd, 0x05, 0xba,
-	0x05, 0x6b, 0x26, 0x25, 0xdc, 0x35, 0x4c, 0xae, 0x07, 0xc9, 0xf2, 0x63, 0xb9, 0x16, 0xc8, 0x0f,
-	0x64, 0xd2, 0x8e, 0x60, 0x2b, 0xdd, 0xc7, 0x64, 0xaa, 0x94, 0x0b, 0xa5, 0xea, 0x6b, 0xb8, 0x3e,
-	0x72, 0xf6, 0x80, 0x92, 0x43, 0xc7, 0x0d, 0xaf, 0xf7, 0x7f, 0x11, 0x8a, 0x9a, 0x84, 0x2e, 0x83,
-	0x78, 0x02, 0xcb, 0xa6, 0x94, 0xe5, 0x49, 0xcd, 0x13, 0x66, 0x4b, 0x88, 0x68, 0x1c, 0x21, 0x84,
-	0xb6, 0x2f, 0xcf, 0xcd, 0xbb, 0xec, 0xf5, 0x63, 0x4c, 0xb8, 0x38, 0xb2, 0xbc, 0xa5, 0xf2, 0x10,
-	0xde, 0xc8, 0xb0, 0x96, 0x8c, 0x37, 0x61, 0x05, 0x7b, 0x7b, 0x7a, 0xf4, 0x58, 0x00, 0x87, 0xea,
-	0xda, 0x37, 0x50, 0x12, 0x28, 0xf5, 0xe6, 0x83, 0xdd, 0x3b, 0x2d, 0xfa, 0x10, 0x13, 0xda, 0x8b,
-	0x9c, 0x26, 0x76, 0xcd, 0xdd, 0x3b, 0xd2, 0xb3, 0xbf, 0x48, 0x29, 0x85, 0xb9, 0xe4, 0x52, 0xd0,
-	0x76, 0x64, 0xba, 0xe2, 0xf8, 0x92, 0x5d, 0x11, 0x16, 0x2c, 0x4f, 0x10, 0x38, 0x10, 0x8b, 0x90,
-	0x92, 0xd0, 0x6d, 0x51, 0x61, 0x19, 0xa1, 0x34, 0x69, 0x31, 0x23, 0xa5, 0x38, 0xfe, 0x88, 0xd2,
-	0x64, 0xcc, 0xda, 0xfd, 0x48, 0xa6, 0x9e, 0xb6, 0x19, 0x76, 0x8f, 0xb1, 0x55, 0xe7, 0x9d, 0x5a,
-	0x97, 0x9a, 0x47, 0x01, 0xb5, 0x1b, 0x00, 0x03, 0x86, 0xf5, 0xe3, 0x1d, 0xfd, 0x08, 0x0f, 0x85,
-	0xf9, 0x72, 0x73, 0x79, 0xc0, 0xf0, 0x17, 0x3b, 0x8f, 0xf1, 0x50, 0xdb, 0x8b, 0x64, 0x6b, 0x12,
-	0x61, 0xe4, 0xbc, 0xed, 0x09, 0x82, 0xeb, 0x2b, 0x16, 0x69, 0xce, 0x63, 0x35, 0x3c, 0x93, 0xf3,
-	0x78, 0x85, 0x26, 0xd6, 0x8e, 0xf6, 0x87, 0x22, 0xb3, 0x71, 0x30, 0x6a, 0x87, 0xd1, 0x72, 0xeb,
-	0x3a, 0x3d, 0x87, 0x07, 0x26, 0x62, 0x81, 0xae, 0xc3, 0x32, 0x75, 0x2d, 0xec, 0xea, 0xed, 0xa1,
-	0xcc, 0xc1, 0x92, 0x58, 0xd7, 0x86, 0x68, 0x03, 0xc0, 0xec, 0x1a, 0x4e, 0x4f, 0xf7, 0x1a, 0x5a,
-	0xe9, 0x92, 0xd8, 0xbc, 0x2c, 0x24, 0xad, 0x61, 0x3f, 0x42, 0x61, 0x3e, 0x5a, 0xbe, 0xaf, 0xc1,
-	0x62, 0x07, 0x3b, 0x76, 0x87, 0x97, 0x16, 0x84, 0x58, 0xae, 0xc6, 0x62, 0x5e, 0x1c, 0x8b, 0x99,
-	0xc8, 0x2c, 0xc7, 0x79, 0xcb, 0x58, 0x9f, 0xc3, 0x95, 0x48, 0x7b, 0x0f, 0x8a, 0xf9, 0xad, 0xac,
-	0x62, 0x8e, 0xe0, 0xc8, 0x42, 0x8e, 0x41, 0x84, 0xfd, 0xb6, 0xee, 0x5d, 0x18, 0x79, 0xd1, 0x99,
-	0xe6, 0xca, 0xf7, 0x24, 0x26, 0x0d, 0x69, 0xb4, 0x60, 0x55, 0xdc, 0x2f, 0x9d, 0x53, 0x3d, 0xb8,
-	0xd6, 0x1e, 0x91, 0xed, 0x2c, 0x22, 0xd1, 0x4a, 0x0a, 0x98, 0xe0, 0x08, 0xbc, 0xf6, 0x31, 0xfc,
-	0xdf, 0xef, 0xf1, 0x7e, 0xff, 0xfc, 0x1c, 0x13, 0xab, 0x45, 0xeb, 0xbc, 0x83, 0x6e, 0xc2, 0x2a,
-	0xc3, 0xc4, 0xcb, 0x4c, 0xfc, 0x49, 0xb9, 0xea, 0x4b, 0x83, 0x37, 0xf0, 0x1f, 0x45, 0x76, 0xc3,
-	0x71, 0x80, 0x90, 0xf7, 0x21, 0x14, 0xb9, 0x6b, 0x10, 0x76, 0x88, 0x5d, 0xa6, 0x3b, 0x44, 0x8f,
-	0xb7, 0xab, 0x4a, 0xae, 0xb7, 0x5d, 0xda, 0xb7, 0x4e, 0x64, 0x0c, 0x28, 0x44, 0x7c, 0x44, 0x64,
-	0x47, 0x44, 0x18, 0xd6, 0x07, 0xc4, 0x07, 0xb7, 0xf4, 0x70, 0xbf, 0x34, 0x77, 0x11, 0x37, 0x21,
-	0x60, 0xb0, 0xc5, 0x76, 0x7f, 0x5b, 0x85, 0x05, 0x11, 0x30, 0x3a, 0x82, 0x45, 0x7f, 0xba, 0x41,
-	0x99, 0xe8, 0x93, 0x83, 0x95, 0x5a, 0xcd, 0xad, 0xef, 0x9f, 0xa1, 0x56, 0x40, 0xbf, 0x2b, 0xb0,
-	0x91, 0x39, 0xe7, 0xa0, 0xfa, 0x54, 0xd0, 0x3c, 0xe3, 0x96, 0xfa, 0xc9, 0x45, 0x61, 0x42, 0xca,
-	0xbf, 0x28, 0x50, 0x4c, 0xea, 0x37, 0x68, 0x3f, 0x97, 0x8b, 0x94, 0x26, 0xa7, 0xde, 0x9b, 0xd1,
-	0x3a, 0xe4, 0xf5, 0xa3, 0x02, 0xff, 0x9b, 0x18, 0xa8, 0xd0, 0xde, 0x54, 0xd8, 0xb4, 0x79, 0x4f,
-	0xfd, 0x70, 0x16, 0xd3, 0x90, 0xce, 0xcf, 0x0a, 0xac, 0x27, 0x0c, 0x43, 0xe8, 0xa3, 0xa9, 0xa8,
-	0xe9, 0x63, 0x9a, 0xba, 0x3f, 0x9b, 0x71, 0x48, 0xea, 0x7b, 0x05, 0xae, 0xc6, 0xc6, 0x1a, 0x74,
-	0x37, 0x1f, 0xe2, 0xd8, 0x90, 0xa5, 0x7e, 0x70, 0x5e, 0xb3, 0x90, 0xc2, 0x77, 0x70, 0x25, 0xfa,
-	0x7a, 0xa1, 0xf7, 0xa7, 0x22, 0x25, 0x8c, 0x25, 0xea, 0xdd, 0x73, 0x5a, 0x45, 0xdd, 0x47, 0x7b,
-	0x7e, 0x0e, 0xf7, 0x09, 0x23, 0x48, 0x0e, 0xf7, 0x49, 0x83, 0x85, 0x56, 0x40, 0xbf, 0x2a, 0xf0,
-	0x7a, 0x03, 0xf3, 0xa4, 0x09, 0x20, 0x67, 0xfd, 0xa4, 0x8c, 0x1e, 0x39, 0xeb, 0x27, 0x6d, 0xec,
-	0x48, 0xa5, 0xe6, 0x5f, 0xda, 0x73, 0x53, 0x8b, 0xdd, 0xda, 0x7b, 0x33, 0x5a, 0x47, 0xaf, 0xed,
-	0xb5, 0x06, 0xe6, 0xd1, 0x36, 0x9e, 0x23, 0x71, 0x09, 0xd3, 0x4a, 0x8e, 0xc4, 0x25, 0xcd, 0x0a,
-	0x5a, 0x01, 0x7d, 0x0b, 0x6b, 0x0d, 0xcc, 0x63, 0x2d, 0x3c, 0x47, 0x7f, 0x88, 0xe9, 0xe7, 0x28,
-	0x9a, 0xc4, 0x11, 0x41, 0x2b, 0xa0, 0x1f, 0x14, 0x58, 0x6f, 0x60, 0x3e, 0xd1, 0xcd, 0x77, 0xa6,
-	0x77, 0x9c, 0x31, 0x13, 0x75, 0xef, 0xdc, 0x26, 0x23, 0x1e, 0xb5, 0xc6, 0xcb, 0xd3, 0xb2, 0xf2,
-	0xea, 0xb4, 0xac, 0xfc, 0x7d, 0x5a, 0x56, 0x7e, 0x3a, 0x2b, 0x17, 0x5e, 0x9d, 0x95, 0x0b, 0x7f,
-	0x9e, 0x95, 0x0b, 0x5f, 0xbd, 0x6b, 0x3b, 0xbc, 0x33, 0x68, 0x57, 0x4c, 0xda, 0xab, 0x26, 0xfc,
-	0x9c, 0x38, 0x89, 0xff, 0xc6, 0x68, 0x2f, 0x8a, 0x1f, 0x14, 0xef, 0xfd, 0x1b, 0x00, 0x00, 0xff,
-	0xff, 0x94, 0xe9, 0xb4, 0xa0, 0x10, 0x12, 0x00, 0x00,
+	// 1212 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x58, 0xdf, 0x6f, 0x1b, 0xc5,
+	0x13, 0xf7, 0xa5, 0xf9, 0xd5, 0x49, 0x9b, 0xe4, 0xbb, 0xf1, 0x17, 0xdc, 0x23, 0x71, 0xc2, 0x49,
+	0x85, 0x14, 0x8a, 0xdd, 0x04, 0x5a, 0x14, 0x48, 0xab, 0xc6, 0xc5, 0x58, 0x55, 0x29, 0x6d, 0x8d,
+	0x05, 0x12, 0x42, 0x9c, 0xce, 0x77, 0x9b, 0xf3, 0x29, 0xf6, 0xae, 0x7b, 0xbb, 0x8e, 0x62, 0x09,
+	0x24, 0x24, 0xc4, 0x1b, 0x12, 0x88, 0x27, 0xde, 0xf9, 0x07, 0x78, 0xe2, 0x6f, 0xe8, 0x63, 0x1f,
+	0x79, 0x42, 0x28, 0x79, 0xe7, 0x6f, 0x40, 0xb7, 0xb7, 0x77, 0xb9, 0xb3, 0xcf, 0xe7, 0xb3, 0xc3,
+	0x9b, 0x77, 0x76, 0xe6, 0x33, 0x9f, 0xd9, 0x99, 0xb9, 0x19, 0x19, 0xde, 0xe8, 0x1a, 0x6d, 0xda,
+	0x31, 0xcc, 0x96, 0xe1, 0x90, 0xb2, 0xff, 0xbb, 0x6c, 0xbb, 0xc6, 0xb1, 0xc3, 0xfb, 0xe5, 0xe7,
+	0x3d, 0xec, 0xf6, 0x4b, 0x5d, 0x97, 0x72, 0x8a, 0xd4, 0x88, 0x5e, 0xc9, 0xff, 0x5d, 0x92, 0x7a,
+	0xea, 0xf5, 0x14, 0x8c, 0x2e, 0xa5, 0x6d, 0x1f, 0x42, 0x4d, 0x73, 0xd5, 0x34, 0xb8, 0xd9, 0x92,
+	0x7a, 0x37, 0x53, 0xf4, 0x0c, 0xce, 0x31, 0xe3, 0x06, 0x77, 0x28, 0x91, 0xda, 0x79, 0x9b, 0xda,
+	0x54, 0xfc, 0x2c, 0x7b, 0xbf, 0xa4, 0x74, 0xdd, 0xa6, 0xd4, 0x6e, 0xe3, 0xb2, 0xd1, 0x75, 0xca,
+	0x06, 0x21, 0xd4, 0x37, 0x61, 0xf2, 0x76, 0x3b, 0xc5, 0x83, 0x8d, 0x09, 0x66, 0x0e, 0xcb, 0xc0,
+	0x99, 0xf7, 0xbb, 0x38, 0xd0, 0x4b, 0x7b, 0x82, 0x0e, 0xb3, 0xa5, 0x9a, 0x96, 0x07, 0xf4, 0xcc,
+	0x7b, 0xd4, 0xa7, 0x86, 0x6b, 0x74, 0x58, 0x1d, 0x3f, 0xef, 0x61, 0xc6, 0xb5, 0x2f, 0x60, 0x2d,
+	0x26, 0x65, 0x5d, 0x4a, 0x18, 0x46, 0xf7, 0x61, 0xbe, 0x2b, 0x24, 0x05, 0x65, 0x4b, 0xd9, 0x5e,
+	0xda, 0xd5, 0x4a, 0xa3, 0x73, 0x50, 0xf2, 0x6d, 0x2b, 0xb3, 0x2f, 0xfe, 0xda, 0xcc, 0xd5, 0xa5,
+	0x9d, 0x56, 0x85, 0x1b, 0x02, 0xf8, 0x13, 0x83, 0xf1, 0xa7, 0x98, 0x58, 0x0e, 0xb1, 0x2b, 0xde,
+	0x43, 0x4b, 0xc7, 0x95, 0xfe, 0x81, 0x65, 0xb9, 0xf2, 0x80, 0x0a, 0xb0, 0x60, 0x58, 0x96, 0x8b,
+	0x99, 0xef, 0xef, 0x72, 0x3d, 0x38, 0x6a, 0x3d, 0x78, 0x2b, 0x0b, 0x8c, 0xa4, 0x5d, 0x83, 0x39,
+	0x91, 0xcd, 0x82, 0xb2, 0x75, 0x69, 0x7b, 0x69, 0xf7, 0xed, 0x34, 0xd6, 0x4f, 0x7a, 0xdc, 0xa6,
+	0x0e, 0xb1, 0x1b, 0x27, 0x02, 0x50, 0xd2, 0xf7, 0xed, 0x35, 0x07, 0x36, 0x84, 0xdb, 0x01, 0x25,
+	0x1c, 0xbc, 0x1b, 0xba, 0x09, 0x48, 0xa0, 0xea, 0x2e, 0x3e, 0xc4, 0x2e, 0x26, 0x26, 0xd6, 0x1d,
+	0x4b, 0x92, 0x5f, 0x15, 0x37, 0xf5, 0xe0, 0xe2, 0xa1, 0x85, 0x54, 0x58, 0x34, 0x18, 0x73, 0x6c,
+	0x82, 0x71, 0x61, 0x46, 0xe8, 0x84, 0x67, 0xad, 0x03, 0xc5, 0x51, 0xae, 0x64, 0x54, 0x8f, 0x60,
+	0xa1, 0xe9, 0x8b, 0xa6, 0x8f, 0x2b, 0x40, 0xd0, 0x9a, 0xb0, 0x29, 0xdc, 0xc5, 0x5f, 0xf1, 0x53,
+	0x4a, 0x4c, 0x1c, 0xc4, 0x96, 0x87, 0x39, 0xe2, 0x9d, 0x45, 0x38, 0xb3, 0x75, 0xff, 0x80, 0x6e,
+	0xc0, 0xaa, 0x49, 0x09, 0x77, 0x0d, 0x93, 0xeb, 0x41, 0xb2, 0xfc, 0x58, 0x56, 0x02, 0xf9, 0x81,
+	0x4c, 0xda, 0x11, 0x6c, 0x8d, 0xf6, 0x31, 0x9c, 0x2a, 0xe5, 0x42, 0xa9, 0xfa, 0x0a, 0xae, 0x9d,
+	0x3b, 0x7b, 0x40, 0xc9, 0xa1, 0xe3, 0x86, 0xe5, 0xfd, 0x5f, 0x84, 0xa2, 0x26, 0xa1, 0xcb, 0x20,
+	0x1e, 0xc3, 0xa2, 0x29, 0x65, 0x59, 0x52, 0xf3, 0x98, 0xd9, 0x12, 0x22, 0x1a, 0x47, 0x08, 0xa1,
+	0xad, 0x4b, 0x67, 0x5e, 0xb1, 0x57, 0x8f, 0x31, 0xe1, 0xd1, 0xb4, 0x68, 0xfb, 0xf2, 0x55, 0xe3,
+	0xb7, 0x59, 0x1b, 0xe9, 0x1e, 0xbc, 0x96, 0x88, 0x2d, 0x23, 0xd9, 0x84, 0x25, 0xec, 0x49, 0xf5,
+	0xe8, 0x73, 0x01, 0x0e, 0x15, 0xb5, 0xaf, 0xa1, 0x20, 0xec, 0xab, 0xf5, 0x07, 0xbb, 0xb7, 0x1a,
+	0xf4, 0x23, 0x4c, 0x68, 0x27, 0xf2, 0xca, 0xd8, 0x35, 0x77, 0x6f, 0x49, 0x9f, 0xfe, 0x61, 0x44,
+	0x8b, 0xcc, 0x24, 0xb7, 0x88, 0xb6, 0x23, 0xd3, 0x18, 0xc7, 0x97, 0xec, 0xf2, 0x30, 0x67, 0x79,
+	0x82, 0xc0, 0x81, 0x38, 0x84, 0x94, 0x84, 0x6e, 0x83, 0x0a, 0xcb, 0x08, 0xa5, 0x61, 0x8b, 0x29,
+	0x29, 0xc5, 0xf1, 0xcf, 0x29, 0x0d, 0xc7, 0xac, 0xdd, 0x8f, 0xe4, 0xe8, 0x49, 0x93, 0x61, 0xf7,
+	0x18, 0x5b, 0x55, 0xde, 0xaa, 0xb4, 0xa9, 0x79, 0x14, 0x50, 0x5b, 0x07, 0xe8, 0x31, 0xac, 0x1f,
+	0xef, 0xe8, 0x47, 0xb8, 0x2f, 0xcc, 0x17, 0xeb, 0x8b, 0x3d, 0x86, 0x3f, 0xdf, 0x79, 0x84, 0xfb,
+	0xda, 0x1e, 0xbc, 0x9e, 0x82, 0x70, 0xee, 0xbc, 0xe9, 0x09, 0x82, 0xb2, 0x16, 0x87, 0x51, 0xce,
+	0x63, 0xbd, 0x3d, 0x95, 0xf3, 0x78, 0xa9, 0x24, 0xf6, 0x94, 0xf6, 0x87, 0x22, 0xb3, 0x71, 0x70,
+	0x3e, 0x26, 0xa3, 0x6d, 0xd8, 0x76, 0x3a, 0x0e, 0x0f, 0x4c, 0xc4, 0x01, 0x5d, 0x83, 0x45, 0xea,
+	0x5a, 0xd8, 0xd5, 0x9b, 0x7d, 0x99, 0x83, 0x05, 0x71, 0xae, 0xf4, 0xd1, 0x06, 0x80, 0xd9, 0x36,
+	0x9c, 0x8e, 0xee, 0x0d, 0xba, 0xc2, 0x25, 0x71, 0x79, 0x59, 0x48, 0x1a, 0xfd, 0x6e, 0x84, 0xc2,
+	0x6c, 0xb4, 0xad, 0x5f, 0x81, 0xf9, 0x16, 0x76, 0xec, 0x16, 0x2f, 0xcc, 0x09, 0xb1, 0x3c, 0x0d,
+	0xc4, 0x3c, 0x3f, 0x10, 0x33, 0x91, 0x59, 0x8e, 0xf3, 0x96, 0xb1, 0x3e, 0x83, 0x2b, 0x91, 0xb1,
+	0x1f, 0x34, 0xf9, 0x9b, 0x69, 0x4d, 0x1e, 0xc1, 0x91, 0x0d, 0x1e, 0x83, 0x08, 0xe7, 0x70, 0xd5,
+	0x2b, 0x18, 0x59, 0xe8, 0x4c, 0x73, 0x65, 0xeb, 0xc7, 0xa4, 0x21, 0x8d, 0x06, 0x2c, 0x8b, 0xfa,
+	0xd2, 0x39, 0xd5, 0x83, 0xb2, 0xf6, 0x88, 0x6c, 0xa7, 0x11, 0x89, 0x76, 0x52, 0xc0, 0x04, 0x47,
+	0xe0, 0xb5, 0x7b, 0xf0, 0x7f, 0x7f, 0xf6, 0xfb, 0x73, 0xf5, 0x33, 0x4c, 0xac, 0x06, 0xad, 0xf2,
+	0x16, 0xba, 0x0e, 0xcb, 0x0c, 0x13, 0x2f, 0x33, 0xf1, 0x8f, 0xc9, 0x55, 0x5f, 0x1a, 0x7c, 0x1b,
+	0xff, 0x51, 0xe4, 0x94, 0x1c, 0x04, 0x08, 0x79, 0x1f, 0x42, 0x9e, 0xbb, 0x06, 0x61, 0x87, 0xd8,
+	0x65, 0xba, 0x43, 0xf4, 0xf8, 0x18, 0x2b, 0x65, 0xfa, 0xe6, 0x4b, 0xfb, 0xc6, 0x89, 0x8c, 0x01,
+	0x85, 0x88, 0x0f, 0x89, 0x9c, 0x94, 0x08, 0xc3, 0x5a, 0x8f, 0xf8, 0xe0, 0x96, 0x1e, 0xde, 0x17,
+	0x66, 0x2e, 0xe2, 0x26, 0x04, 0x0c, 0xae, 0xd8, 0xee, 0x6f, 0x2b, 0x30, 0x27, 0x02, 0x46, 0x47,
+	0x30, 0xef, 0x6f, 0x3d, 0x28, 0x15, 0x7d, 0x78, 0xe1, 0x52, 0xcb, 0x99, 0xf5, 0xfd, 0x37, 0xd4,
+	0x72, 0xe8, 0x77, 0x05, 0x36, 0x52, 0xf7, 0x1f, 0x54, 0x1d, 0x0b, 0x9a, 0x65, 0x0d, 0x53, 0x3f,
+	0xbe, 0x28, 0x4c, 0x48, 0xf9, 0x7b, 0x05, 0x96, 0xe3, 0x93, 0x06, 0xdd, 0xc9, 0x04, 0x3e, 0x34,
+	0xf6, 0xd4, 0xf7, 0x27, 0xb6, 0x0b, 0x59, 0xfc, 0xa4, 0x40, 0x3e, 0x69, 0x5a, 0xa2, 0xfd, 0x09,
+	0x31, 0xe3, 0xcf, 0x74, 0x01, 0x46, 0x3f, 0x2a, 0xf0, 0xbf, 0xa1, 0x45, 0x0f, 0xed, 0x8d, 0x05,
+	0x1c, 0xb5, 0x87, 0xaa, 0x1f, 0x4c, 0x63, 0x1a, 0xd2, 0xf9, 0x45, 0x81, 0xb5, 0x84, 0x25, 0x0d,
+	0x7d, 0x38, 0x16, 0x75, 0xf4, 0xfa, 0xa8, 0xee, 0x4f, 0x67, 0x1c, 0x92, 0xfa, 0x4e, 0x81, 0xab,
+	0xb1, 0x75, 0x0b, 0xdd, 0xce, 0x86, 0x38, 0xb0, 0xfc, 0xa9, 0x77, 0x26, 0x35, 0x0b, 0x29, 0x7c,
+	0x0b, 0x57, 0xa2, 0x5f, 0x4f, 0xf4, 0xde, 0x58, 0xa4, 0x84, 0xb5, 0x48, 0xbd, 0x3d, 0xa1, 0x55,
+	0xd4, 0x7d, 0x74, 0xe7, 0xc8, 0xe0, 0x3e, 0x61, 0x05, 0xca, 0xe0, 0x3e, 0x69, 0xb1, 0xd1, 0x72,
+	0xe8, 0x57, 0x05, 0x5e, 0xad, 0x61, 0x9e, 0xb4, 0x81, 0x64, 0xec, 0x9c, 0x11, 0xab, 0x8f, 0x7a,
+	0x77, 0x4a, 0xeb, 0x31, 0xd4, 0xfc, 0xa2, 0x9d, 0x98, 0x5a, 0xac, 0x6a, 0xef, 0x4e, 0x69, 0x1d,
+	0x2d, 0xdb, 0x95, 0x1a, 0xe6, 0xd1, 0x35, 0x22, 0x43, 0xe2, 0x12, 0xb6, 0xa5, 0x0c, 0x89, 0x4b,
+	0xda, 0x55, 0xb4, 0x1c, 0xfa, 0x06, 0x56, 0x6b, 0x98, 0xc7, 0x56, 0x88, 0x0c, 0xf3, 0x29, 0xa6,
+	0x9f, 0xa1, 0x69, 0x12, 0x57, 0x14, 0x2d, 0x87, 0x7e, 0x50, 0x60, 0xad, 0x86, 0xf9, 0xd0, 0x36,
+	0xb1, 0x33, 0x7e, 0xe2, 0x0d, 0x98, 0xa8, 0x7b, 0x13, 0x9b, 0x9c, 0xf3, 0xa8, 0xd4, 0x5e, 0x9c,
+	0x16, 0x95, 0x97, 0xa7, 0x45, 0xe5, 0xef, 0xd3, 0xa2, 0xf2, 0xf3, 0x59, 0x31, 0xf7, 0xf2, 0xac,
+	0x98, 0xfb, 0xf3, 0xac, 0x98, 0xfb, 0xf2, 0x1d, 0xdb, 0xe1, 0xad, 0x5e, 0xb3, 0x64, 0xd2, 0x4e,
+	0x39, 0xe1, 0x4f, 0x93, 0x93, 0xf8, 0xdf, 0x2b, 0xcd, 0x79, 0xf1, 0xc7, 0xc9, 0xbb, 0xff, 0x06,
+	0x00, 0x00, 0xff, 0xff, 0x54, 0x09, 0x67, 0xa0, 0xa8, 0x12, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ context.Context
-var _ grpc.ClientConn
+var (
+	_ context.Context
+	_ grpc.ClientConn
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
@@ -1411,7 +1588,8 @@ const _ = grpc.SupportPackageIsVersion4
 type QueryClient interface {
 	Params(ctx context.Context, in *QueryParamsRequest, opts ...grpc.CallOption) (*QueryParamsResponse, error)
 	LastPendingBatchRequestByAddr(ctx context.Context, in *QueryLastPendingBatchRequestByAddrRequest, opts ...grpc.CallOption) (*QueryLastPendingBatchRequestByAddrResponse, error)
-	LastEventNonceByAddr(ctx context.Context, in *QueryLastEventNonceByAddrRequest, opts ...grpc.CallOption) (*QueryLastEventNonceByAddrResponse, error)
+	LastEventNonce(ctx context.Context, in *QueryLastEventNonceRequest, opts ...grpc.CallOption) (*QueryLastEventNonceResponse, error)
+	LastEventNonceByAddr(ctx context.Context, in *QueryLastEventNonceByAddrRequest, opts ...grpc.CallOption) (*QueryLastEventNonceResponse, error)
 	OutgoingTxBatches(ctx context.Context, in *QueryOutgoingTxBatchesRequest, opts ...grpc.CallOption) (*QueryOutgoingTxBatchesResponse, error)
 	BatchRequestByNonce(ctx context.Context, in *QueryBatchRequestByNonceRequest, opts ...grpc.CallOption) (*QueryBatchRequestByNonceResponse, error)
 	BatchConfirms(ctx context.Context, in *QueryBatchConfirmsRequest, opts ...grpc.CallOption) (*QueryBatchConfirmsResponse, error)
@@ -1450,8 +1628,17 @@ func (c *queryClient) LastPendingBatchRequestByAddr(ctx context.Context, in *Que
 	return out, nil
 }
 
-func (c *queryClient) LastEventNonceByAddr(ctx context.Context, in *QueryLastEventNonceByAddrRequest, opts ...grpc.CallOption) (*QueryLastEventNonceByAddrResponse, error) {
-	out := new(QueryLastEventNonceByAddrResponse)
+func (c *queryClient) LastEventNonce(ctx context.Context, in *QueryLastEventNonceRequest, opts ...grpc.CallOption) (*QueryLastEventNonceResponse, error) {
+	out := new(QueryLastEventNonceResponse)
+	err := c.cc.Invoke(ctx, "/palomachain.paloma.gravity.Query/LastEventNonce", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *queryClient) LastEventNonceByAddr(ctx context.Context, in *QueryLastEventNonceByAddrRequest, opts ...grpc.CallOption) (*QueryLastEventNonceResponse, error) {
+	out := new(QueryLastEventNonceResponse)
 	err := c.cc.Invoke(ctx, "/palomachain.paloma.gravity.Query/LastEventNonceByAddr", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -1553,7 +1740,8 @@ func (c *queryClient) GetPendingSendToEth(ctx context.Context, in *QueryPendingS
 type QueryServer interface {
 	Params(context.Context, *QueryParamsRequest) (*QueryParamsResponse, error)
 	LastPendingBatchRequestByAddr(context.Context, *QueryLastPendingBatchRequestByAddrRequest) (*QueryLastPendingBatchRequestByAddrResponse, error)
-	LastEventNonceByAddr(context.Context, *QueryLastEventNonceByAddrRequest) (*QueryLastEventNonceByAddrResponse, error)
+	LastEventNonce(context.Context, *QueryLastEventNonceRequest) (*QueryLastEventNonceResponse, error)
+	LastEventNonceByAddr(context.Context, *QueryLastEventNonceByAddrRequest) (*QueryLastEventNonceResponse, error)
 	OutgoingTxBatches(context.Context, *QueryOutgoingTxBatchesRequest) (*QueryOutgoingTxBatchesResponse, error)
 	BatchRequestByNonce(context.Context, *QueryBatchRequestByNonceRequest) (*QueryBatchRequestByNonceResponse, error)
 	BatchConfirms(context.Context, *QueryBatchConfirmsRequest) (*QueryBatchConfirmsResponse, error)
@@ -1567,45 +1755,60 @@ type QueryServer interface {
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
-type UnimplementedQueryServer struct {
-}
+type UnimplementedQueryServer struct{}
 
 func (*UnimplementedQueryServer) Params(ctx context.Context, req *QueryParamsRequest) (*QueryParamsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Params not implemented")
 }
+
 func (*UnimplementedQueryServer) LastPendingBatchRequestByAddr(ctx context.Context, req *QueryLastPendingBatchRequestByAddrRequest) (*QueryLastPendingBatchRequestByAddrResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method LastPendingBatchRequestByAddr not implemented")
 }
-func (*UnimplementedQueryServer) LastEventNonceByAddr(ctx context.Context, req *QueryLastEventNonceByAddrRequest) (*QueryLastEventNonceByAddrResponse, error) {
+
+func (*UnimplementedQueryServer) LastEventNonce(ctx context.Context, req *QueryLastEventNonceRequest) (*QueryLastEventNonceResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method LastEventNonce not implemented")
+}
+
+func (*UnimplementedQueryServer) LastEventNonceByAddr(ctx context.Context, req *QueryLastEventNonceByAddrRequest) (*QueryLastEventNonceResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method LastEventNonceByAddr not implemented")
 }
+
 func (*UnimplementedQueryServer) OutgoingTxBatches(ctx context.Context, req *QueryOutgoingTxBatchesRequest) (*QueryOutgoingTxBatchesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method OutgoingTxBatches not implemented")
 }
+
 func (*UnimplementedQueryServer) BatchRequestByNonce(ctx context.Context, req *QueryBatchRequestByNonceRequest) (*QueryBatchRequestByNonceResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method BatchRequestByNonce not implemented")
 }
+
 func (*UnimplementedQueryServer) BatchConfirms(ctx context.Context, req *QueryBatchConfirmsRequest) (*QueryBatchConfirmsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method BatchConfirms not implemented")
 }
+
 func (*UnimplementedQueryServer) ERC20ToDenom(ctx context.Context, req *QueryERC20ToDenomRequest) (*QueryERC20ToDenomResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ERC20ToDenom not implemented")
 }
+
 func (*UnimplementedQueryServer) DenomToERC20(ctx context.Context, req *QueryDenomToERC20Request) (*QueryDenomToERC20Response, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DenomToERC20 not implemented")
 }
+
 func (*UnimplementedQueryServer) GetLastObservedEthBlock(ctx context.Context, req *QueryLastObservedEthBlockRequest) (*QueryLastObservedEthBlockResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetLastObservedEthBlock not implemented")
 }
+
 func (*UnimplementedQueryServer) GetLastObservedEthNonce(ctx context.Context, req *QueryLastObservedEthNonceRequest) (*QueryLastObservedEthNonceResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetLastObservedEthNonce not implemented")
 }
+
 func (*UnimplementedQueryServer) GetAttestations(ctx context.Context, req *QueryAttestationsRequest) (*QueryAttestationsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetAttestations not implemented")
 }
+
 func (*UnimplementedQueryServer) GetErc20ToDenoms(ctx context.Context, req *QueryErc20ToDenoms) (*QueryErc20ToDenomsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetErc20ToDenoms not implemented")
 }
+
 func (*UnimplementedQueryServer) GetPendingSendToEth(ctx context.Context, req *QueryPendingSendToEth) (*QueryPendingSendToEthResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetPendingSendToEth not implemented")
 }
@@ -1646,6 +1849,24 @@ func _Query_LastPendingBatchRequestByAddr_Handler(srv interface{}, ctx context.C
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(QueryServer).LastPendingBatchRequestByAddr(ctx, req.(*QueryLastPendingBatchRequestByAddrRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Query_LastEventNonce_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryLastEventNonceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).LastEventNonce(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/palomachain.paloma.gravity.Query/LastEventNonce",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).LastEventNonce(ctx, req.(*QueryLastEventNonceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1859,6 +2080,10 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "LastPendingBatchRequestByAddr",
 			Handler:    _Query_LastPendingBatchRequestByAddr_Handler,
+		},
+		{
+			MethodName: "LastEventNonce",
+			Handler:    _Query_LastEventNonce_Handler,
 		},
 		{
 			MethodName: "LastEventNonceByAddr",
@@ -2246,6 +2471,29 @@ func (m *QueryBatchConfirmsResponse) MarshalToSizedBuffer(dAtA []byte) (int, err
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryLastEventNonceRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryLastEventNonceRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryLastEventNonceRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func (m *QueryLastEventNonceByAddrRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -2276,7 +2524,7 @@ func (m *QueryLastEventNonceByAddrRequest) MarshalToSizedBuffer(dAtA []byte) (in
 	return len(dAtA) - i, nil
 }
 
-func (m *QueryLastEventNonceByAddrResponse) Marshal() (dAtA []byte, err error) {
+func (m *QueryLastEventNonceResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -2286,12 +2534,12 @@ func (m *QueryLastEventNonceByAddrResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *QueryLastEventNonceByAddrResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *QueryLastEventNonceResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *QueryLastEventNonceByAddrResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *QueryLastEventNonceResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -2811,6 +3059,7 @@ func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *QueryParamsRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -2949,6 +3198,15 @@ func (m *QueryBatchConfirmsResponse) Size() (n int) {
 	return n
 }
 
+func (m *QueryLastEventNonceRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
 func (m *QueryLastEventNonceByAddrRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -2962,7 +3220,7 @@ func (m *QueryLastEventNonceByAddrRequest) Size() (n int) {
 	return n
 }
 
-func (m *QueryLastEventNonceByAddrResponse) Size() (n int) {
+func (m *QueryLastEventNonceResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -3187,9 +3445,11 @@ func (m *QueryPendingSendToEthResponse) Size() (n int) {
 func sovQuery(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozQuery(x uint64) (n int) {
 	return sovQuery(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *QueryParamsRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3240,6 +3500,7 @@ func (m *QueryParamsRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryParamsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3323,6 +3584,7 @@ func (m *QueryParamsResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryLastPendingBatchRequestByAddrRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3405,6 +3667,7 @@ func (m *QueryLastPendingBatchRequestByAddrRequest) Unmarshal(dAtA []byte) error
 	}
 	return nil
 }
+
 func (m *QueryLastPendingBatchRequestByAddrResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3489,6 +3752,7 @@ func (m *QueryLastPendingBatchRequestByAddrResponse) Unmarshal(dAtA []byte) erro
 	}
 	return nil
 }
+
 func (m *QueryOutgoingTxBatchesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3603,6 +3867,7 @@ func (m *QueryOutgoingTxBatchesRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryOutgoingTxBatchesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3687,6 +3952,7 @@ func (m *QueryOutgoingTxBatchesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryBatchRequestByNonceRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3788,6 +4054,7 @@ func (m *QueryBatchRequestByNonceRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryBatchRequestByNonceResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3871,6 +4138,7 @@ func (m *QueryBatchRequestByNonceResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryBatchConfirmsRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3972,6 +4240,7 @@ func (m *QueryBatchConfirmsRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryBatchConfirmsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4056,6 +4325,58 @@ func (m *QueryBatchConfirmsResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
+func (m *QueryLastEventNonceRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryLastEventNonceRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryLastEventNonceRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
 func (m *QueryLastEventNonceByAddrRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4138,7 +4459,8 @@ func (m *QueryLastEventNonceByAddrRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *QueryLastEventNonceByAddrResponse) Unmarshal(dAtA []byte) error {
+
+func (m *QueryLastEventNonceResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -4161,10 +4483,10 @@ func (m *QueryLastEventNonceByAddrResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: QueryLastEventNonceByAddrResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: QueryLastEventNonceResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: QueryLastEventNonceByAddrResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: QueryLastEventNonceResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -4207,6 +4529,7 @@ func (m *QueryLastEventNonceByAddrResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryERC20ToDenomRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4321,6 +4644,7 @@ func (m *QueryERC20ToDenomRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryERC20ToDenomResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4403,6 +4727,7 @@ func (m *QueryERC20ToDenomResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryDenomToERC20Request) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4517,6 +4842,7 @@ func (m *QueryDenomToERC20Request) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryDenomToERC20Response) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4599,6 +4925,7 @@ func (m *QueryDenomToERC20Response) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryLastObservedEthBlockRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4669,6 +4996,7 @@ func (m *QueryLastObservedEthBlockRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryLastObservedEthBlockResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4738,6 +5066,7 @@ func (m *QueryLastObservedEthBlockResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryLastObservedEthNonceRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4808,6 +5137,7 @@ func (m *QueryLastObservedEthNonceRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryLastObservedEthNonceResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4877,6 +5207,7 @@ func (m *QueryLastObservedEthNonceResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryAttestationsRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5068,6 +5399,7 @@ func (m *QueryAttestationsRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryAttestationsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5152,6 +5484,7 @@ func (m *QueryAttestationsResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryErc20ToDenoms) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5202,6 +5535,7 @@ func (m *QueryErc20ToDenoms) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryErc20ToDenomsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5286,6 +5620,7 @@ func (m *QueryErc20ToDenomsResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryPendingSendToEth) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5368,6 +5703,7 @@ func (m *QueryPendingSendToEth) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryPendingSendToEthResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5486,6 +5822,7 @@ func (m *QueryPendingSendToEthResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipQuery(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/959

# Background

This adds a new GRPC query to retrieve the last observed event nonce from Paloma. Pigeons will use this information in order to build their own state.

# Testing completed

- Will be tested in TN together with the Pigeon change

# Breaking changes

- [ ] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
