### PR TITLE
fix: prevent panic in job execution command

### DIFF
--- a/x/scheduler/keeper/msg_server_execute_job.go
+++ b/x/scheduler/keeper/msg_server_execute_job.go
@@ -14,7 +14,13 @@ func (msgSrv msgServer) ExecuteJob(goCtx context.Context, msg *types.MsgExecuteJ
 	logger.Debug("Received ExecuteJob message.")
 
 	// Find the public key of the sender
-	senderAddress := msgSrv.GetAccount(ctx, sdk.AccAddress(msg.GetMetadata().Creator)).GetAddress()
+	creator, err := sdk.AccAddressFromBech32(msg.GetMetadata().GetCreator())
+	if err != nil {
+		logger.WithError(err).Error("Failed to parse message creator.")
+		return nil, err
+	}
+
+	senderAddress := msgSrv.GetAccount(ctx, creator).GetAddress()
 
 	msgID, err := msgSrv.Keeper.ExecuteJob(ctx, msg.GetJobID(), msg.GetPayload(), senderAddress, nil)
 	if err != nil {


### PR DESCRIPTION
This panic crept in with the changes made to support Pigeon keys and went through unnoticed until today. This fix addresses the problem by calling the proper parsing function. There is unfortunately ZERO testing in place for CLI commands still. Hopefully something we can tackle in the future so things like this don't happen again.