### PR TITLE
fix: ante handler skip condition

### DIFF
--- a/x/paloma/ante.go
+++ b/x/paloma/ante.go
@@ -78,7 +78,7 @@ func NewVerifyAuthorisedSignatureDecorator(fk types.FeegrantKeeper) VerifyAuthor
 // AnteHandle verifies that the message is signed by at least one signature that has
 // active fee grant from the creator address, IF the message contains metadata.
 func (d VerifyAuthorisedSignatureDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	if simulate || ctx.IsCheckTx() {
+	if simulate {
 		return next(ctx, tx, simulate)
 	}
 


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1014
- https://github.com/VolumeFi/paloma/issues/1013

# Background

After more investigation, it's become apparent that there are transactions which are being rejected in the CometBFT mempool, I don't think they ever reach the app mempool. 

The reason for the rejection is the account sequence mismatch. Theoretically, this should be verified when submitting a transaction.

Looking at the code, there is a precondition in our ante handler for signature verification that's being skipped if we're running `CheckTX` - so it's possible for a transaction that would actually fail to still be included in the mempool, as it looks like the check is only run once the TX is actually executed.

Tested this in public test net against a dev build and had promising results, meaning most TXs got rejected and evicted during the `CheckTX` stage. 

However, 6 transactions remain to be stuck. I'm not entirely sure why. It's possible they're being re-broadcasted from the other nodes. Once all validators upgrade to the next version with this change in place, we will know.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
