### PR TITLE
fix: panic on contract deployment

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -554,7 +554,7 @@ func New(
 		app.ValsetKeeper,
 	)
 	app.ValsetKeeper.SnapshotListeners = []valsetmoduletypes.OnSnapshotBuiltListener{
-		app.EvmKeeper,
+		&app.EvmKeeper,
 	}
 	app.ValsetKeeper.EvmKeeper = app.EvmKeeper
 
@@ -571,7 +571,9 @@ func New(
 		gravitymodulekeeper.NewGravityStoreGetter(keys[gravitymoduletypes.StoreKey]),
 	)
 	// TODO: Use proper dependency resolution instead of
-	// this abomination
+	// this abomination.
+	// TODO: Refactor app to use pointer values only instead
+	// of keeping value copies and blowing up the stack.
 	app.EvmKeeper.Gravity = app.GravityKeeper
 
 	app.PalomaKeeper = *palomamodulekeeper.NewKeeper(
@@ -739,7 +741,7 @@ func New(
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.
 
-	evmModule := evm.NewAppModule(appCodec, app.EvmKeeper, app.AccountKeeper, app.BankKeeper)
+	evmModule := evm.NewAppModule(appCodec, app.EvmKeeper)
 	consensusModule := consensusmodule.NewAppModule(appCodec, app.ConsensusKeeper, app.AccountKeeper, app.BankKeeper)
 	valsetModule := valsetmodule.NewAppModule(appCodec, app.ValsetKeeper, app.AccountKeeper, app.BankKeeper)
 	schedulerModule := schedulermodule.NewAppModule(appCodec, app.SchedulerKeeper, app.AccountKeeper, app.BankKeeper)

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -88,7 +88,7 @@ func init() {
 	}
 }
 
-var _ valsettypes.OnSnapshotBuiltListener = Keeper{}
+var _ valsettypes.OnSnapshotBuiltListener = &Keeper{}
 
 type Keeper struct {
 	cdc        codec.BinaryCodec
@@ -534,7 +534,7 @@ func (k Keeper) PublishSnapshotToAllChains(ctx sdk.Context, snapshot *valsettype
 	return nil
 }
 
-func (k Keeper) OnSnapshotBuilt(ctx sdk.Context, snapshot *valsettypes.Snapshot) {
+func (k *Keeper) OnSnapshotBuilt(ctx sdk.Context, snapshot *valsettypes.Snapshot) {
 	err := k.PublishSnapshotToAllChains(ctx, snapshot, false)
 	if err != nil {
 		panic(err)

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -94,22 +94,16 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 type AppModule struct {
 	AppModuleBasic
 
-	keeper        keeper.Keeper
-	accountKeeper types.AccountKeeper
-	bankKeeper    types.BankKeeper
+	keeper keeper.Keeper
 }
 
 func NewAppModule(
 	cdc codec.Codec,
 	keeper keeper.Keeper,
-	accountKeeper types.AccountKeeper,
-	bankKeeper types.BankKeeper,
 ) AppModule {
 	return AppModule{
 		AppModuleBasic: NewAppModuleBasic(cdc),
 		keeper:         keeper,
-		accountKeeper:  accountKeeper,
-		bankKeeper:     bankKeeper,
 	}
 }
 


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1031

# Background

So, the app initialisation code is the biggest heap of steaming 💩 I have seen in a long time. 

- For starters, the consumed keepers from both the Cosmos and the Paloma stack are stored in a chaotic way. Sometimes it's a value, sometimes it's a pointer, sometimes it's an interface. Why? Don't know.
- Since some of the keepers have cyclic dependencies on each other (which by default should be a big red flag), some injection of dependencies is happening manually post initialisation. This obviously behaves differently depending on how the keeper is stored. Why not use proper DI? Don't know. There's an [app v2 document](https://docs.cosmos.network/main/build/building-apps/app-go-v2) on Cosmos that outlines a more modular way of wiring up the app. We should take a look at this some time.
- Some of Paloma's modules try to employ more of a implicit, reactive nature by using event subscriptions. For some reason, there's like 3 different implementations of the same logic across those modules. Why? Don't know. But manually defining the event consumers at application startup is error prone and tedious.

TL;DR: Since there is no clear, enforced guideline on how an app stores it's dependencies and keepers, there's a lot of spaghetti. In combination with manual post init DI as well as passing said dependencies by value directly, it can lead to very hard to debug runtime exceptions because of missing dependencies. All in all, it's just bad craftsmanship and we should rewrite the entire init logic once we get a chance.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
