### PR TITLE
feat: log inbox queries

### DIFF
--- a/x/consensus/keeper/query_queued_messages_for_relaying.go
+++ b/x/consensus/keeper/query_queued_messages_for_relaying.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/palomachain/paloma/util/liblog"
 	"github.com/palomachain/paloma/x/consensus/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -14,9 +15,13 @@ func (k Keeper) QueuedMessagesForRelaying(goCtx context.Context, req *types.Quer
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	logger := liblog.FromSDKLogger(k.Logger(ctx)).WithFields(
+		"component", "queued-messages-for-relaying",
+		"sender", req.ValAddress.String())
 
 	msgs, err := k.GetMessagesForRelaying(ctx, req.QueueTypeName, req.ValAddress)
 	if err != nil {
+		logger.WithError(err).Error("Failed to query messages for relaying.")
 		return nil, err
 	}
 
@@ -25,12 +30,18 @@ func (k Keeper) QueuedMessagesForRelaying(goCtx context.Context, req *types.Quer
 		if msg.GetRequireSignatures() {
 			msgWithSignatures, err := k.queuedMessageToMessageWithSignatures(msg)
 			if err != nil {
+				logger.WithError(err).Error("Failed to parse queued message to message with signatures.")
 				return nil, err
 			}
 			res = append(res, msgWithSignatures)
 		}
 	}
 
+	msgIDs := make([]uint64, len(res))
+	for i, v := range res {
+		msgIDs[i] = v.Id
+	}
+	logger.WithFields("messages", msgIDs).Debug("Queried for pending messages.")
 	return &types.QueryQueuedMessagesForRelayingResponse{
 		Messages: res,
 	}, nil


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1036

# Background

This change adds logging debug information for inbox queries.

# Testing completed

- [x] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
