### PR TITLE
chore: reduce consensus msg lifetime

### DIFF
--- a/x/consensus/module.go
+++ b/x/consensus/module.go
@@ -171,7 +171,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 	}
 
 	if ctx.BlockHeight()%50 == 0 {
-		err := am.keeper.PruneOldMessages(ctx, 1200)
+		err := am.keeper.PruneOldMessages(ctx, 300)
 		if err != nil {
 			am.keeper.Logger(ctx).Error("error while deleting old messages", "err", err)
 		}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1036

# Background

Changes the lifetime of a consensus message to 300 blocks, approximately 8 minutes with an average block speed of 1.6 seconds per block.

Before automatic reassignment of messages, a message would stay in the queue for up to 1200 blocks, giving the assigned validator some time to fix ongoing issues.

With the reassignment of tardy messages in place, there's no need for messages to stay around considerably longer than 100 blocks really, but with 300 blocks we still get some opportunity to inspect what's going on in logs.

We can reduce this value further to something like 100 or even 50 once we're confident with our relay stability.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
