### PR TITLE
Add bare bone error wrapping library

### DIFF
--- a/util/liberr/error.go
+++ b/util/liberr/error.go
@@ -1,0 +1,45 @@
+package liberr
+
+import (
+	"errors"
+	"fmt"
+)
+
+type Error string
+
+func (e Error) Error() string {
+	return string(e)
+}
+
+func (e Error) Format(a ...any) internalErr {
+	return internalErr{
+		e:   e,
+		msg: fmt.Sprintf(e.Error(), a...),
+	}
+}
+
+func (e Error) JoinErrorf(format string, args ...any) Error {
+	return e.Join(fmt.Errorf(format, args...))
+}
+
+func (e Error) Join(errs ...error) Error {
+	return Error(errors.Join(append([]error{e}, errs...)...).Error())
+}
+
+type internalErr struct {
+	e   Error
+	msg string
+}
+
+func (e internalErr) Error() string {
+	return e.msg
+}
+
+func (e internalErr) Is(target error) bool {
+	return errors.Is(e.e, target)
+}
+
+func (e internalErr) JoinErrorf(format string, args ...any) internalErr {
+	e.msg = errors.Join(e, fmt.Errorf(format, args...)).Error()
+	return e
+}

--- a/util/liberr/error_test.go
+++ b/util/liberr/error_test.go
@@ -1,0 +1,22 @@
+package liberr_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/palomachain/paloma/util/liberr"
+	"github.com/stretchr/testify/require"
+)
+
+const dummyErr = liberr.Error("not found: %s")
+
+func TestFormat(t *testing.T) {
+	e := dummyErr.Format("foo")
+
+	fmt.Println(errors.Is(e, dummyErr))
+	require.True(t, errors.Is(e, dummyErr))
+
+	e = e.JoinErrorf("with extra info: %s", "bar")
+	require.True(t, errors.Is(e, dummyErr))
+}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1159
- https://github.com/VolumeFi/paloma/issues/875

# Background

There's a lot of dynamic error messages being built in legacy Paloma code that relies on outdated error handling patterns. This small util package helps with defining constant errors while still allowing for dynamic error messages and working pattern matching.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [ ] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
