### PR TITLE
hotfix: prevent punishing missing attestants for unhandled msg

### DIFF
--- a/x/consensus/keeper/concensus_keeper.go
+++ b/x/consensus/keeper/concensus_keeper.go
@@ -281,6 +281,12 @@ func (k Keeper) jailValidatorsWhichMissedAttestation(ctx sdk.Context, queueTypeN
 		return fmt.Errorf("getMsgByID: %w", err)
 	}
 
+	if msg.GetPublicAccessData() == nil && msg.GetErrorData() == nil {
+		// This message was never successfully handled, attestation flock
+		// should not be punished for this.
+		return nil
+	}
+
 	if _, err := k.consensusChecker.VerifyEvidence(ctx, msg.GetEvidence()); err == nil {
 		return fmt.Errorf("unexpected message with valid consensus found, skipping jailing steps")
 	}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1409

# Background

Some messages might still fail to be handled at all, meaning the message will not even enter the attestation phase. In this case, we do not want to punish validators - otherwise we'd jail the entire network.

Merging this into `devel`, which was taken from `release/v1.12.2`. That will be my working branch for a `v1.12.3` release in case `master` remains blocked due to the Cosmos upgrade.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
