### PR TITLE
fix: prevent TPK when not attesting faulty msg

### DIFF
--- a/util/libcons/consensus.go
+++ b/util/libcons/consensus.go
@@ -148,7 +148,6 @@ func (c ConsensusChecker) VerifyEvidence(ctx sdk.Context, evidences []*consensus
 	// TODO: gas management
 	// TODO: punishing validators who misbehave
 	// TODO: check for every tx if it seems genuine
-
 	for hash, group := range groups {
 
 		var cp consensusPower

--- a/x/consensus/keeper/cleanup_test.go
+++ b/x/consensus/keeper/cleanup_test.go
@@ -6,9 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/palomachain/paloma/x/consensus/keeper/consensus"
 	"github.com/palomachain/paloma/x/consensus/types"
-	valsettypes "github.com/palomachain/paloma/x/valset/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,7 +21,7 @@ func TestDeleteOldMessages(t *testing.T) {
 			name:      "deletes messages over a number of blocks ago, but not messages under",
 			blocksAgo: 50,
 			setup: func() (Keeper, sdk.Context, string) {
-				k, ms, ctx := newConsensusKeeper(t)
+				k, _, ctx := newConsensusKeeper(t)
 				queue := types.Queue(defaultQueueName, chainType, chainReferenceID)
 
 				msgType := &types.SimpleMessage{}
@@ -64,7 +62,7 @@ func TestDeleteOldMessages(t *testing.T) {
 
 				// Advance to block 61
 				ctx = ctx.WithBlockHeight(61)
-				ms.ValsetKeeper.On("GetCurrentSnapshot", mock.Anything).Return(&valsettypes.Snapshot{}, nil)
+				// ms.ValsetKeeper.On("GetCurrentSnapshot", mock.Anything).Return(&valsettypes.Snapshot{}, nil)
 
 				return *k, ctx, queue
 			},

--- a/x/consensus/keeper/cleanup_test.go
+++ b/x/consensus/keeper/cleanup_test.go
@@ -62,7 +62,6 @@ func TestDeleteOldMessages(t *testing.T) {
 
 				// Advance to block 61
 				ctx = ctx.WithBlockHeight(61)
-				// ms.ValsetKeeper.On("GetCurrentSnapshot", mock.Anything).Return(&valsettypes.Snapshot{}, nil)
 
 				return *k, ctx, queue
 			},


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1425

# Background

This change adds two safe guards to prevent a mass jailing in case of a faulty message:

a) messages that do not build consensus because neither `errorData` nor `publicAccessData` has been added, meaning the message was never handled in the first place. Nobody should be punished for not attesting what's not attestable.
b) messages that less than 10% of the network attest are treated as indications of faulty message responses which cannot be attested to even when tried. Nobody will be punished for missing attestation on such a message.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
