### PR TITLE
chore: increase go version to 1.22.2 and fix libwasm version

### DIFF
--- a/cmd/palomad/commands.go
+++ b/cmd/palomad/commands.go
@@ -6,6 +6,7 @@ import (
 
 	cosmoslog "cosmossdk.io/log"
 	confixcmd "cosmossdk.io/tools/confix/cmd"
+	"github.com/CosmWasm/wasmd/x/wasm"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/debug"
@@ -124,6 +125,7 @@ func genesisCommand(encodingConfig params.EncodingConfig, basicManager module.Ba
 
 func addModuleInitFlags(startCmd *cobra.Command) {
 	crisis.AddModuleInitFlags(startCmd)
+	wasm.AddModuleInitFlags(startCmd)
 }
 
 func queryCommand(mm module.BasicManager) *cobra.Command {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/palomachain/paloma
 
-go 1.21
+go 1.22.2
 
 require (
 	cosmossdk.io/errors v1.0.1


### PR DESCRIPTION
- Increase Go version to `1.22.2`
- Fix libwasm version during application startup