### PR TITLE
fix: include v prefix in app version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22.2'
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Create release

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GOLANGCILINT_VERSION := 1.51.2
 ###############################################################################
 
 ifeq (,$(VERSION))
-  VERSION := $(shell git describe --exact-match --tags 2>/dev/null | sed 's/^v//')
+  VERSION := $(shell git describe --exact-match --tags 2>/dev/null)
   # if VERSION is empty, then populate it with branch's name and raw commit hash
   ifeq (,$(VERSION))
     VERSION := $(BRANCH)-$(COMMIT)


### PR DESCRIPTION
The leading v prefix in the app version is used both in CI builds
as well as the test net setup. Pigeon also uses it. It makes
no sense to remove it from manual builds, especially as it can
lead to differences in state.
