### PR TITLE
chore: bump Pigeon version

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ rm -r ~/.paloma/data/wasm/cache
 ### To get the latest prebuilt `palomad` binary:
 
 ```shell
-wget -O - https://github.com/palomachain/paloma/releases/download/v1.13.4/paloma_Linux_x86_64.tar.gz  | \
+wget -O - https://github.com/palomachain/paloma/releases/download/v1.13.5/paloma_Linux_x86_64.tar.gz  | \
   sudo tar -C /usr/local/bin -xvzf - palomad
 sudo chmod +x /usr/local/bin/palomad
 ```
@@ -107,7 +107,7 @@ sudo chmod +x /usr/local/bin/palomad
 ```shell
 git clone https://github.com/palomachain/paloma.git
 cd paloma
-git checkout v1.13.4
+git checkout v1.13.5
 make build
 sudo mv ./build/palomad /usr/local/bin/palomad
 ```

--- a/app/app.go
+++ b/app/app.go
@@ -156,7 +156,7 @@ const (
 
 	wasmAvailableCapabilities = "iterator,staking,stargate,paloma"
 
-	minimumPigeonVersion = "v1.11.1"
+	minimumPigeonVersion = "v1.11.2"
 )
 
 func getGovProposalHandlers() []govclient.ProposalHandler {


### PR DESCRIPTION
Bump Pigeon to `v1.11.2` and update README