### PR TITLE
Fix panics picked up by Codeql

### DIFF
--- a/util/keeper/errors.go
+++ b/util/keeper/errors.go
@@ -1,9 +1,13 @@
 package keeper
 
 import (
+	"errors"
+
 	"github.com/VolumeFi/whoops"
 )
 
 const (
 	ErrNotFound = whoops.Errorf("item (%T) not found in store: %s")
 )
+
+var ErrUnknownPanic = errors.New("unknown panic")

--- a/x/consensus/keeper/concensus_keeper.go
+++ b/x/consensus/keeper/concensus_keeper.go
@@ -52,9 +52,9 @@ func (k Keeper) getConsensusQueue(ctx context.Context, queueTypeName string) (co
 		}
 
 		if opts.Batched {
-			return consensus.NewBatchQueue(opts.QueueOptions), nil
+			return consensus.NewBatchQueue(opts.QueueOptions)
 		}
-		return consensus.NewQueue(opts.QueueOptions), nil
+		return consensus.NewQueue(opts.QueueOptions)
 	}
 	return nil, ErrConsensusQueueNotImplemented.Format(queueTypeName)
 }

--- a/x/consensus/keeper/consensus/batch.go
+++ b/x/consensus/keeper/consensus/batch.go
@@ -18,15 +18,21 @@ type BatchQueue struct {
 	batchedTypeChecker types.TypeChecker
 }
 
-func NewBatchQueue(qo QueueOptions) BatchQueue {
+func NewBatchQueue(qo QueueOptions) (BatchQueue, error) {
 	staticTypeCheck := qo.TypeCheck
 	batchedTypeCheck := types.BatchedTypeChecker(staticTypeCheck)
 
 	qo.TypeCheck = batchedTypeCheck
-	return BatchQueue{
-		base:               NewQueue(qo),
-		batchedTypeChecker: staticTypeCheck,
+
+	base, err := NewQueue(qo)
+	if err != nil {
+		return BatchQueue{}, err
 	}
+
+	return BatchQueue{
+		base:               base,
+		batchedTypeChecker: staticTypeCheck,
+	}, nil
 }
 
 func (c BatchQueue) Put(ctx context.Context, msg ConsensusMsg, opts *PutOptions) (uint64, error) {

--- a/x/consensus/keeper/consensus/batch.go
+++ b/x/consensus/keeper/consensus/batch.go
@@ -56,13 +56,24 @@ func (c BatchQueue) Put(ctx context.Context, msg ConsensusMsg, opts *PutOptions)
 	if err != nil {
 		return 0, err
 	}
-	c.batchQueue(sdkCtx).Set(sdk.Uint64ToBigEndian(newID), data)
+
+	batchQueue, err := c.batchQueue(sdkCtx)
+	if err != nil {
+		return 0, err
+	}
+
+	batchQueue.Set(sdk.Uint64ToBigEndian(newID), data)
 	return newID, nil
 }
 
 func (c BatchQueue) ProcessBatches(ctx context.Context) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	queue := c.batchQueue(sdkCtx)
+
+	queue, err := c.batchQueue(sdkCtx)
+	if err != nil {
+		return err
+	}
+
 	deleteKeys := [][]byte{}
 
 	iterator := queue.Iterator(nil, nil)
@@ -110,10 +121,16 @@ func (c BatchQueue) ProcessBatches(ctx context.Context) error {
 }
 
 // batchQueue returns queue of messages that have been batched
-func (c BatchQueue) batchQueue(ctx context.Context) prefix.Store {
+func (c BatchQueue) batchQueue(ctx context.Context) (prefix.Store, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	store := c.base.qo.Sg.Store(sdkCtx)
-	return prefix.NewStore(store, []byte("batching:"+c.base.signingQueueKey()))
+
+	key, err := c.base.signingQueueKey()
+	if err != nil {
+		return prefix.Store{}, err
+	}
+
+	return prefix.NewStore(store, []byte("batching:"+key)), nil
 }
 
 func (c BatchQueue) AddSignature(ctx context.Context, id uint64, signData *types.SignData) error {

--- a/x/consensus/keeper/consensus/batch_test.go
+++ b/x/consensus/keeper/consensus/batch_test.go
@@ -40,7 +40,7 @@ func TestBatching(t *testing.T) {
 
 	sg := keeperutil.SimpleStoreGetter(stateStore.GetKVStore(storeKey))
 	msgType := &types.SimpleMessage{}
-	cq := NewBatchQueue(
+	cq, _ := NewBatchQueue(
 		QueueOptions{
 			QueueTypeName: "simple-message",
 			Sg:            sg,

--- a/x/consensus/keeper/consensus/consensus.go
+++ b/x/consensus/keeper/consensus/consensus.go
@@ -94,31 +94,34 @@ func ApplyOpts(opts *QueueOptions, fncs ...OptFnc) *QueueOptions {
 	return opts
 }
 
-func NewQueue(qo QueueOptions) Queue {
+func NewQueue(qo QueueOptions) (Queue, error) {
 	if qo.TypeCheck == nil {
-		panic("TypeCheck can't be nil")
+		return Queue{}, ErrNilTypeCheck
 	}
+
 	if qo.BytesToSignCalculator == nil {
-		panic("BytesToSignCalculator can't be nil")
+		return Queue{}, ErrNilBytesToSignCalculator
 	}
+
 	if qo.VerifySignature == nil {
-		panic("VerifySignature can't be nil")
+		return Queue{}, ErrNilVerifySignature
 	}
 
 	if len(qo.ChainType) == 0 {
-		panic("chain type can't be empty")
+		return Queue{}, ErrEmptyChainType
 	}
 
 	if len(qo.ChainReferenceID) == 0 {
-		panic("chain id can't be empty")
+		return Queue{}, ErrEmptyChainReferenceID
 	}
 
 	if len(qo.QueueTypeName) == 0 {
-		panic("queue type name can't be empty")
+		return Queue{}, ErrEmptyQueueTypeName
 	}
+
 	return Queue{
 		qo: qo,
-	}
+	}, nil
 }
 
 // Put puts raw message into a signing queue.

--- a/x/consensus/keeper/consensus/errors.go
+++ b/x/consensus/keeper/consensus/errors.go
@@ -1,6 +1,8 @@
 package consensus
 
 import (
+	"errors"
+
 	"github.com/VolumeFi/whoops"
 )
 
@@ -13,11 +15,13 @@ const (
 	ErrValidatorAlreadySigned       = whoops.Errorf("validator already signed: %s")
 
 	ErrAttestorNotSetForMessage = whoops.Errorf("attestator must be set for message: %T")
+)
 
-	ErrNilTypeCheck             = whoops.String("TypeCheck can't be nil")
-	ErrNilBytesToSignCalculator = whoops.String("BytesToSignCalculator can't be nil")
-	ErrNilVerifySignature       = whoops.String("VerifySignature can't be nil")
-	ErrEmptyChainType           = whoops.String("chain type can't be empty")
-	ErrEmptyChainReferenceID    = whoops.String("chain id can't be empty")
-	ErrEmptyQueueTypeName       = whoops.String("queue type name can't be empty")
+var (
+	ErrNilTypeCheck             = errors.New("TypeCheck can't be nil")
+	ErrNilBytesToSignCalculator = errors.New("BytesToSignCalculator can't be nil")
+	ErrNilVerifySignature       = errors.New("VerifySignature can't be nil")
+	ErrEmptyChainType           = errors.New("chain type can't be empty")
+	ErrEmptyChainReferenceID    = errors.New("chain id can't be empty")
+	ErrEmptyQueueTypeName       = errors.New("queue type name can't be empty")
 )

--- a/x/consensus/keeper/consensus/errors.go
+++ b/x/consensus/keeper/consensus/errors.go
@@ -13,4 +13,11 @@ const (
 	ErrValidatorAlreadySigned       = whoops.Errorf("validator already signed: %s")
 
 	ErrAttestorNotSetForMessage = whoops.Errorf("attestator must be set for message: %T")
+
+	ErrNilTypeCheck             = whoops.String("TypeCheck can't be nil")
+	ErrNilBytesToSignCalculator = whoops.String("BytesToSignCalculator can't be nil")
+	ErrNilVerifySignature       = whoops.String("VerifySignature can't be nil")
+	ErrEmptyChainType           = whoops.String("chain type can't be empty")
+	ErrEmptyChainReferenceID    = whoops.String("chain id can't be empty")
+	ErrEmptyQueueTypeName       = whoops.String("queue type name can't be empty")
 )

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -558,7 +558,8 @@ func (k Keeper) PublishSnapshotToAllChains(ctx context.Context, snapshot *valset
 func (k Keeper) OnSnapshotBuilt(ctx context.Context, snapshot *valsettypes.Snapshot) {
 	err := k.PublishSnapshotToAllChains(ctx, snapshot, false)
 	if err != nil {
-		panic(err)
+		k.Logger(ctx).WithError(err).Warn("Failed to publish snapshot to all chains.")
+		return
 	}
 
 	k.TryDeployingLastCompassContractToAllChains(ctx)

--- a/x/evm/keeper/scheduler_job.go
+++ b/x/evm/keeper/scheduler_job.go
@@ -26,7 +26,8 @@ func (k Keeper) XChainType() xchain.Type {
 func (k Keeper) XChainReferenceIDs(ctx context.Context) []xchain.ReferenceID {
 	chainInfos, err := k.GetAllChainInfos(ctx)
 	if err != nil {
-		panic(err)
+		k.Logger(ctx).WithError(err).Warn("Failed to get all chains infos")
+		return nil
 	}
 
 	return slice.Map(chainInfos, func(ci *types.ChainInfo) xchain.ReferenceID {

--- a/x/valset/keeper/keeper.go
+++ b/x/valset/keeper/keeper.go
@@ -609,7 +609,7 @@ func (k Keeper) Jail(_ctx context.Context, valAddr sdk.ValAddress, reason string
 			case string:
 				jailingErr = whoops.String(t)
 			default:
-				panic(r)
+				jailingErr = keeperutil.ErrUnknownPanic
 			}
 		}()
 


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1591

# Background

Clanup possible runtime panics picked up by CodeQL analysis.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [ ] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.

# Notes

CodeQL still reports 6 panics in BeginBlock or EndBlock - [here](https://github.com/palomachain/paloma/security/code-scanning?query=%22Panic+in+BeginBlock%22+is%3Aopen+pr%3A1172+) - but I think we want to keep those. They all come from 2 points in the code:
- [CheckChainVersion](https://github.com/palomachain/paloma/blob/546372207dd2eb535590697c49264ab1d1e1b152/x/paloma/module.go#L174-L174) to make sure we're running the intended palomad version
- [Closing attestation iterators](https://github.com/palomachain/paloma/blob/546372207dd2eb535590697c49264ab1d1e1b152/x/gravity/keeper/attestation.go#L314-L314) - since we can't close the iterator, it is my understanding we won't be able to write to this iterator. So just returning an error could lead to further issues down the line.
