### PR TITLE
fix: gravity genesis export

### DIFF
--- a/x/gravity/keeper/genesis.go
+++ b/x/gravity/keeper/genesis.go
@@ -51,6 +51,12 @@ func InitGenesis(ctx context.Context, k Keeper, data types.GenesisState) {
 		k.setID(ctx, nonce.LastBatchId, []byte(types.KeyLastOutgoingBatchID))
 	}
 
+	if len(data.GravityNonces) == 0 {
+		if err := k.SetLastSlashedBatchBlock(ctx, 0); err != nil {
+			panic(err)
+		}
+	}
+
 	initBridgeDataFromGenesis(ctx, k, data)
 
 	// reset pool transactions in state


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1654

# Background

The `GravityNonces` changed to an array, so now we have to call `SetLastSlashedBatchBlock` manually if it's empty.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
