### PR TITLE
chore: jail validators with invalid balances

### DIFF
--- a/x/evm/types/jail_reason.go
+++ b/x/evm/types/jail_reason.go
@@ -2,4 +2,5 @@ package types
 
 const (
 	JailReasonNotEnoughFunds = "not enough funds in the target chain (%s). Has %s. Min required: %s."
+	JailReasonInvalidBalance = "invalid balance information in the target chain (%s): %s."
 )


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1037

# Background

If validators have invalid (or missing) balances, we jail them. Alternatively we could leave them out of the relayer pool, but this makes it more visible when something has failed.

For this mechanism to work properly, we need https://github.com/palomachain/pigeon/pull/399 to be merged as well.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
