### PR TITLE
fix: withold gravity batches until valset update

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -595,6 +595,7 @@ func New(
 		app.DistrKeeper,
 		app.TransferKeeper,
 		app.EvmKeeper,
+		app.ConsensusKeeper,
 		gravitymodulekeeper.NewGravityStoreGetter(keys[gravitymoduletypes.StoreKey]),
 		authorityAddress,
 		authcodec.NewBech32Codec(chainparams.ValidatorAddressPrefix),

--- a/tests/integration/evm/keeper/keeper_integration_test.go
+++ b/tests/integration/evm/keeper/keeper_integration_test.go
@@ -127,7 +127,7 @@ func TestEndToEndForEvmArbitraryCall(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	queue := consensustypes.Queue(keeper.ConsensusTurnstoneMessage, chainType, chainReferenceID)
+	queue := consensustypes.Queue(types.ConsensusTurnstoneMessage, chainType, chainReferenceID)
 	msgs, err := f.consensusKeeper.GetMessagesForSigning(ctx, queue, operator)
 	require.NoError(t, err)
 
@@ -208,7 +208,7 @@ func TestFirstSnapshot_OnSnapshotBuilt(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	queue := fmt.Sprintf("evm/%s/%s", newChain.GetChainReferenceID(), keeper.ConsensusTurnstoneMessage)
+	queue := fmt.Sprintf("evm/%s/%s", newChain.GetChainReferenceID(), types.ConsensusTurnstoneMessage)
 	msgs, err := f.consensusKeeper.GetMessagesFromQueue(ctx, queue, 100)
 	require.NoError(t, err)
 	require.Empty(t, msgs)
@@ -279,7 +279,7 @@ func TestRecentPublishedSnapshot_OnSnapshotBuilt(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	queue := fmt.Sprintf("evm/%s/%s", newChain.GetChainReferenceID(), keeper.ConsensusTurnstoneMessage)
+	queue := fmt.Sprintf("evm/%s/%s", newChain.GetChainReferenceID(), types.ConsensusTurnstoneMessage)
 
 	msgs, err := f.consensusKeeper.GetMessagesFromQueue(ctx, queue, 1)
 	require.NoError(t, err)
@@ -386,7 +386,7 @@ func TestOldPublishedSnapshot_OnSnapshotBuilt(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	queue := fmt.Sprintf("evm/%s/%s", newChain.GetChainReferenceID(), keeper.ConsensusTurnstoneMessage)
+	queue := fmt.Sprintf("evm/%s/%s", newChain.GetChainReferenceID(), types.ConsensusTurnstoneMessage)
 
 	msgs, err := f.consensusKeeper.GetMessagesFromQueue(ctx, queue, 1)
 	require.NoError(t, err)
@@ -463,7 +463,7 @@ func TestInactiveChain_OnSnapshotBuilt(t *testing.T) {
 		f.stakingKeeper.SetValidator(ctx, val)
 	}
 
-	queue := fmt.Sprintf("evm/%s/%s", "bob", keeper.ConsensusTurnstoneMessage)
+	queue := fmt.Sprintf("evm/%s/%s", "bob", types.ConsensusTurnstoneMessage)
 
 	_, err := f.valsetKeeper.TriggerSnapshotBuild(ctx)
 	require.NoError(t, err)

--- a/tests/integration/evm/keeper/test_helpers_test.go
+++ b/tests/integration/evm/keeper/test_helpers_test.go
@@ -311,6 +311,7 @@ func initFixture(t ginkgo.FullGinkgoTInterface) *fixture {
 		distrKeeper,
 		transferKeeper,
 		evmKeeper,
+		consensusKeeper,
 		gravitymodulekeeper.NewGravityStoreGetter(keys[gravitymoduletypes.StoreKey]),
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		authcodec.NewBech32Codec(params2.ValidatorAddressPrefix),

--- a/util/eventbus/bus.go
+++ b/util/eventbus/bus.go
@@ -1,0 +1,54 @@
+package eventbus
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/palomachain/paloma/util/liblog"
+)
+
+var gravityBatchBuilt = newEvent[GravityBatchBuiltEvent]()
+
+type (
+	EventHandler[E any] func(context.Context, E) error
+	Event[E any]        struct {
+		subscribers map[string]EventHandler[E]
+	}
+)
+
+func newEvent[E any]() Event[E] {
+	return Event[E]{
+		subscribers: make(map[string]EventHandler[E]),
+	}
+}
+
+func (e Event[E]) Publish(ctx context.Context, event E) {
+	for s, fn := range e.subscribers {
+		if fn != nil {
+			logger := liblog.FromSDKLogger(sdk.UnwrapSDKContext(ctx).Logger()).
+				WithComponent("eventbus").
+				WithFields("event", event).
+				WithFields("subscriber", s)
+			logger.Debug("Handling event")
+			if err := fn(ctx, event); err != nil {
+				logger.WithError(err).Error("Failed to handle event")
+			}
+		}
+	}
+}
+
+func (e Event[E]) Subscribe(id string, fn EventHandler[E]) {
+	e.subscribers[id] = fn
+}
+
+func (e Event[E]) Unsubscribe(id string) {
+	e.subscribers[id] = nil
+}
+
+type GravityBatchBuiltEvent struct {
+	ChainReferenceID string
+}
+
+func GravityBatchBuilt() *Event[GravityBatchBuiltEvent] {
+	return &gravityBatchBuilt
+}

--- a/util/eventbus/bus_test.go
+++ b/util/eventbus/bus_test.go
@@ -1,0 +1,48 @@
+package eventbus_test
+
+import (
+	"context"
+	"testing"
+
+	"cosmossdk.io/log"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/palomachain/paloma/util/eventbus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventBus(t *testing.T) {
+	ctx := sdk.Context{}.
+		WithLogger(log.NewNopLogger()).
+		WithContext(context.Background())
+	eventbus.GravityBatchBuilt().Publish(ctx, eventbus.GravityBatchBuiltEvent{
+		ChainReferenceID: "test-chain",
+	})
+
+	calls := make(map[string]int)
+	fn := func(_ context.Context, e eventbus.GravityBatchBuiltEvent) error {
+		calls[e.ChainReferenceID]++
+		return nil
+	}
+
+	eventbus.GravityBatchBuilt().Subscribe("test-1", fn)
+	require.Len(t, calls, 0, "should be empty")
+
+	eventbus.GravityBatchBuilt().Publish(ctx, eventbus.GravityBatchBuiltEvent{
+		ChainReferenceID: "test-chain",
+	})
+
+	require.NotNil(t, calls["test-chain"], "should have executed one.")
+	require.Equal(t, 1, calls["test-chain"], "should have executed one.")
+
+	eventbus.GravityBatchBuilt().Subscribe("test-2", fn)
+	eventbus.GravityBatchBuilt().Publish(ctx, eventbus.GravityBatchBuiltEvent{
+		ChainReferenceID: "test-chain",
+	})
+	require.Equal(t, 3, calls["test-chain"], "should execute both subscribers.")
+
+	eventbus.GravityBatchBuilt().Unsubscribe("test-1")
+	eventbus.GravityBatchBuilt().Publish(ctx, eventbus.GravityBatchBuiltEvent{
+		ChainReferenceID: "test-chain",
+	})
+	require.Equal(t, 4, calls["test-chain"], "should have removed one subscriber.")
+}

--- a/x/evm/keeper/smart_contract_deployment.go
+++ b/x/evm/keeper/smart_contract_deployment.go
@@ -164,7 +164,7 @@ func (k Keeper) AddSmartContractExecutionToConsensus(
 	return k.ConsensusKeeper.PutMessageInQueue(
 		ctx,
 		consensustypes.Queue(
-			ConsensusTurnstoneMessage,
+			types.ConsensusTurnstoneMessage,
 			xchainType,
 			chainReferenceID,
 		),
@@ -311,7 +311,7 @@ func (k Keeper) AddUploadSmartContractToConsensus(
 	return k.ConsensusKeeper.PutMessageInQueue(
 		ctx,
 		consensustypes.Queue(
-			ConsensusTurnstoneMessage,
+			types.ConsensusTurnstoneMessage,
 			xchainType,
 			chainReferenceID,
 		),

--- a/x/evm/types/types.go
+++ b/x/evm/types/types.go
@@ -1,1 +1,3 @@
 package types
+
+const ConsensusTurnstoneMessage = "evm-turnstone-message"

--- a/x/gravity/keeper/batch.go
+++ b/x/gravity/keeper/batch.go
@@ -11,6 +11,7 @@ import (
 	"cosmossdk.io/store/prefix"
 	"github.com/VolumeFi/whoops"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/palomachain/paloma/util/eventbus"
 	"github.com/palomachain/paloma/x/gravity/types"
 )
 
@@ -76,6 +77,10 @@ func (k Keeper) BuildOutgoingTXBatch(
 	if err != nil {
 		return nil, err
 	}
+
+	eventbus.GravityBatchBuilt().Publish(ctx, eventbus.GravityBatchBuiltEvent{
+		ChainReferenceID: chainReferenceID,
+	})
 
 	return batch, sdkCtx.EventManager().EmitTypedEvent(
 		&types.EventOutgoingBatch{

--- a/x/gravity/keeper/grpc_query_test.go
+++ b/x/gravity/keeper/grpc_query_test.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"bytes"
+	"math/big"
 	"testing"
 	"time"
 
@@ -237,12 +238,18 @@ func TestLastBatchesRequest(t *testing.T) {
 
 	defer func() { sdkCtx.Logger().Info("Asserting invariants at test end"); input.AssertInvariants() }()
 
+	// evm/test-chain/evm-turnstone-message
+	// evm/test-chain/evm-turnstone-message
+	input.EvmKeeper.AddSupportForNewChain(ctx, "test-chain", 42, 100, "0x123", big.NewInt(0))
+
 	k := input.GravityKeeper
 
 	createTestBatch(t, input, 2)
 	createTestBatch(t, input, 3)
 
-	lastBatches, err := k.OutgoingTxBatches(ctx, &types.QueryOutgoingTxBatchesRequest{})
+	lastBatches, err := k.OutgoingTxBatches(ctx, &types.QueryOutgoingTxBatchesRequest{
+		ChainReferenceId: "test-chain",
+	})
 	require.NoError(t, err)
 
 	expectedRes := types.QueryOutgoingTxBatchesResponse{

--- a/x/gravity/keeper/keeper.go
+++ b/x/gravity/keeper/keeper.go
@@ -39,6 +39,7 @@ type Keeper struct {
 	accountKeeper     types.AccountKeeper
 	ibcTransferKeeper ibctransferkeeper.Keeper
 	evmKeeper         types.EVMKeeper
+	consensusKeeper   types.ConsensusKeeper
 	AddressCodec      address.Codec
 	storeGetter       keeperutil.StoreGetter
 
@@ -58,6 +59,7 @@ func NewKeeper(
 	distributionKeeper distrkeeper.Keeper,
 	ibcTransferKeeper ibctransferkeeper.Keeper,
 	evmKeeper types.EVMKeeper,
+	consensusKeeper types.ConsensusKeeper,
 	storeGetter keeperutil.StoreGetter,
 	authority string,
 	valAddressCodec address.Codec,
@@ -71,6 +73,7 @@ func NewKeeper(
 		accountKeeper:      accKeeper,
 		ibcTransferKeeper:  ibcTransferKeeper,
 		evmKeeper:          evmKeeper,
+		consensusKeeper:    consensusKeeper,
 		storeGetter:        storeGetter,
 		AttestationHandler: nil,
 		AddressCodec:       valAddressCodec,

--- a/x/gravity/keeper/test_common.go
+++ b/x/gravity/keeper/test_common.go
@@ -277,6 +277,7 @@ type TestInput struct {
 	Marshaler         codec.Codec
 	LegacyAmino       *codec.LegacyAmino
 	GravityStoreKey   *storetypes.KVStoreKey
+	EvmKeeper         evmkeeper.Keeper
 }
 
 func addValidators(t *testing.T, input *TestInput, count int) {
@@ -725,6 +726,8 @@ func CreateTestEnv(t *testing.T) TestInput {
 	)
 	require.NoError(t, err)
 
+	consensusRegistry.Add(evmKeeper)
+
 	k := NewKeeper(
 		marshaler,
 		accountKeeper,
@@ -734,6 +737,7 @@ func CreateTestEnv(t *testing.T) TestInput {
 		distKeeper,
 		ibcTransferKeeper,
 		evmKeeper,
+		consensusKeeper,
 		NewGravityStoreGetter(gravityKey),
 		"",
 		authcodec.NewBech32Codec(chainparams.ValidatorAddressPrefix),
@@ -811,6 +815,7 @@ func CreateTestEnv(t *testing.T) TestInput {
 		Context:           ctx,
 		Marshaler:         marshaler,
 		LegacyAmino:       legacyAmino,
+		EvmKeeper:         *evmKeeper,
 	}
 
 	sdkCtx := sdk.UnwrapSDKContext(testInput.Context)

--- a/x/gravity/types/expected_keepers.go
+++ b/x/gravity/types/expected_keepers.go
@@ -11,6 +11,7 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	xchain "github.com/palomachain/paloma/internal/x-chain"
+	consensustypes "github.com/palomachain/paloma/x/consensus/types"
 	evmtypes "github.com/palomachain/paloma/x/evm/types"
 )
 
@@ -49,6 +50,10 @@ type BankKeeper interface {
 
 type SlashingKeeper interface {
 	GetValidatorSigningInfo(ctx context.Context, address sdk.ConsAddress) (info slashingtypes.ValidatorSigningInfo, found error)
+}
+
+type ConsensusKeeper interface {
+	GetPendingValsetUpdates(ctx context.Context, queueTypeName string) ([]consensustypes.QueuedSignedMessageI, error)
 }
 
 // AccountKeeper defines the interface contract required for account


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1464

# Background

This change adds a new constraint when handing out gravity batches to be relayed. They will now be withheld while valset updates are pending on the target chain, just like with SLC. I had to cut some corners to get this out sooner rather than later, but I also added a more decentralised event bus system for decoupling systems. It's currently very bare bone and as singleton hard to test, but if it grows, we can refactor into something more injectible.

# Testing completed

- [x] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
