### PR TITLE
fix: unpack errors on ReferenceBlockAttestation

### DIFF
--- a/x/consensus/keeper/concensus_keeper.go
+++ b/x/consensus/keeper/concensus_keeper.go
@@ -183,6 +183,11 @@ func (k Keeper) GetMessagesForRelaying(ctx context.Context, queueTypeName string
 		return msg.GetId() <= valsetUpdatesOnChain[0].GetId()
 	})
 
+	// Filter down to just messages that have neither publicAccessData nor errorData
+	msgs = slice.Filter(msgs, func(msg types.QueuedSignedMessageI) bool {
+		return msg.GetPublicAccessData() == nil && msg.GetErrorData() == nil
+	})
+
 	// Filter down to just messages assigned to this validator
 	msgs = slice.Filter(msgs, func(msg types.QueuedSignedMessageI) bool {
 		var unpackedMsg evmtypes.TurnstoneMsg
@@ -192,11 +197,6 @@ func (k Keeper) GetMessagesForRelaying(ctx context.Context, queueTypeName string
 		}
 
 		return unpackedMsg.GetAssignee() == valAddress.String()
-	})
-
-	// Filter down to just messages that have neither publicAccessData nor errorData
-	msgs = slice.Filter(msgs, func(msg types.QueuedSignedMessageI) bool {
-		return msg.GetPublicAccessData() == nil && msg.GetErrorData() == nil
 	})
 
 	if len(msgs) > defaultResponseMessageCount {


### PR DESCRIPTION
# Related Github tickets

- Closes https://github.com/VolumeFi/paloma/issues/1740

# Background

ReferenceBlockAttestation messages currently do not need an assignee, however they are still queried for messages to relay, leading to unpack error messages in palomad logs.
By first checking for publicAccessData, ReferenceBlockAttestation messages are filtered before we try to unpack them as TurnstoneMsg and avoid the errors.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
