### PR TITLE
feat: Prevent parallel delivery of same sender msgs

### DIFF
--- a/x/consensus/keeper/filters/assigned_to_filter.go
+++ b/x/consensus/keeper/filters/assigned_to_filter.go
@@ -1,0 +1,7 @@
+package filters
+
+import evmtypes "github.com/palomachain/paloma/x/evm/types"
+
+func IsAssignedTo(msg *evmtypes.Message, assignee string) bool {
+	return msg.GetAssignee() == assignee
+}

--- a/x/consensus/keeper/filters/assigned_to_filter_test.go
+++ b/x/consensus/keeper/filters/assigned_to_filter_test.go
@@ -1,0 +1,17 @@
+package filters
+
+import (
+	"testing"
+
+	evmtypes "github.com/palomachain/paloma/x/evm/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_IsAssignedTo(t *testing.T) {
+	msg := &evmtypes.Message{
+		Assignee: "assignee",
+	}
+	assignee := "assignee"
+	assert.True(t, IsAssignedTo(msg, assignee))
+	assert.False(t, IsAssignedTo(msg, "assignee1"))
+}

--- a/x/consensus/keeper/filters/is_oldest_per_sender_filter.go
+++ b/x/consensus/keeper/filters/is_oldest_per_sender_filter.go
@@ -1,0 +1,27 @@
+package filters
+
+import evmtypes "github.com/palomachain/paloma/x/evm/types"
+
+// Biased: Filter expects messages to be ordered by message ID (default)
+// Filter requires injection of a look-up table to keep track of senders
+// Filter out multiple messages from same sender
+// This is done to avoid possible relays of more messages than
+// user is able to pay for.
+func IsOldestMsgPerSender(lut map[string]struct{}, msg *evmtypes.Message) bool {
+	slc := msg.GetSubmitLogicCall()
+	if slc == nil {
+		return true
+	}
+	if len(slc.GetSenderAddress()) < 1 {
+		return true
+	}
+	sender := string(slc.GetSenderAddress())
+	if _, fnd := lut[sender]; fnd {
+		// One message for this sender was already included in the
+		// result set.
+		return false
+	}
+
+	lut[sender] = struct{}{}
+	return true
+}

--- a/x/consensus/keeper/filters/is_oldest_per_sender_filter_test.go
+++ b/x/consensus/keeper/filters/is_oldest_per_sender_filter_test.go
@@ -1,0 +1,65 @@
+package filters
+
+import evmtypes "github.com/palomachain/paloma/x/evm/types"
+import "testing"
+
+func Test_IsOldestMsgPerSender(t *testing.T) {
+	tests := []struct {
+		name string
+		lut  map[string]struct{}
+		msg  *evmtypes.Message
+		want bool
+	}{
+		{
+			name: "Test IsOldestMsgPerSender with non SLC",
+			lut:  nil,
+			msg:  &evmtypes.Message{},
+			want: true,
+		},
+		{
+			name: "Test IsOldestMsgPerSender without sender address",
+			lut:  nil,
+			msg: &evmtypes.Message{
+				Action: &evmtypes.Message_SubmitLogicCall{
+					SubmitLogicCall: &evmtypes.SubmitLogicCall{
+						SenderAddress: nil,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Test IsOldestMsgPerSender without sender present in LUT",
+			lut:  map[string]struct{}{},
+			msg: &evmtypes.Message{
+				Action: &evmtypes.Message_SubmitLogicCall{
+					SubmitLogicCall: &evmtypes.SubmitLogicCall{
+						SenderAddress: []byte("sender"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Test IsOldestMsgPerSender with sender present in LUT",
+			lut:  map[string]struct{}{"sender": {}},
+			msg: &evmtypes.Message{
+				Action: &evmtypes.Message_SubmitLogicCall{
+					SubmitLogicCall: &evmtypes.SubmitLogicCall{
+						SenderAddress: []byte("sender"),
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsOldestMsgPerSender(tt.lut, tt.msg); got != tt.want {
+				t.Errorf("IsOldestMsgPerSender() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+}

--- a/x/consensus/keeper/filters/is_oldest_per_sender_filter_test.go
+++ b/x/consensus/keeper/filters/is_oldest_per_sender_filter_test.go
@@ -1,7 +1,10 @@
 package filters
 
-import evmtypes "github.com/palomachain/paloma/x/evm/types"
-import "testing"
+import (
+	"testing"
+
+	evmtypes "github.com/palomachain/paloma/x/evm/types"
+)
 
 func Test_IsOldestMsgPerSender(t *testing.T) {
 	tests := []struct {
@@ -61,5 +64,4 @@ func Test_IsOldestMsgPerSender(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/x/consensus/keeper/filters/pending_valset_filter.go
+++ b/x/consensus/keeper/filters/pending_valset_filter.go
@@ -1,0 +1,13 @@
+package filters
+
+import "github.com/palomachain/paloma/x/consensus/types"
+
+func IsNotBlockedByValset(pendingValsetUpdates []types.QueuedSignedMessageI, msg types.QueuedSignedMessageI) bool {
+	if pendingValsetUpdates == nil || len(pendingValsetUpdates) < 1 {
+		return true
+	}
+
+	// Looks like there is a valset update for the target chain,
+	// only return true if this message is younger than the valset update
+	return msg.GetId() <= pendingValsetUpdates[0].GetId()
+}

--- a/x/consensus/keeper/filters/pending_valset_filter_test.go
+++ b/x/consensus/keeper/filters/pending_valset_filter_test.go
@@ -1,7 +1,10 @@
 package filters
 
-import "testing"
-import "github.com/palomachain/paloma/x/consensus/types"
+import (
+	"testing"
+
+	"github.com/palomachain/paloma/x/consensus/types"
+)
 
 func Test_IsNotBlockedByValset(t *testing.T) {
 	tests := []struct {

--- a/x/consensus/keeper/filters/pending_valset_filter_test.go
+++ b/x/consensus/keeper/filters/pending_valset_filter_test.go
@@ -1,0 +1,51 @@
+package filters
+
+import "testing"
+import "github.com/palomachain/paloma/x/consensus/types"
+
+func Test_IsNotBlockedByValset(t *testing.T) {
+	tests := []struct {
+		name                 string
+		pendingValsetUpdates []types.QueuedSignedMessageI
+		msg                  types.QueuedSignedMessageI
+		want                 bool
+	}{
+		{
+			name:                 "Test IsNotBlockedByValset with empty valset updates",
+			pendingValsetUpdates: nil,
+			msg:                  &types.QueuedSignedMessage{},
+			want:                 true,
+		},
+		{
+			name: "Test IsNotBlockedByValset with older message than valset update",
+			pendingValsetUpdates: []types.QueuedSignedMessageI{
+				&types.QueuedSignedMessage{
+					Id: 2,
+				},
+			},
+			msg: &types.QueuedSignedMessage{
+				Id: 1,
+			},
+			want: true,
+		},
+		{
+			name: "Test IsNotBlockedByValset with younger message than valset update",
+			pendingValsetUpdates: []types.QueuedSignedMessageI{
+				&types.QueuedSignedMessage{
+					Id: 1,
+				},
+			},
+			msg: &types.QueuedSignedMessage{
+				Id: 2,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNotBlockedByValset(tt.pendingValsetUpdates, tt.msg); got != tt.want {
+				t.Errorf("IsNotBlockedByValset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/x/consensus/keeper/filters/unprocessed_filter.go
+++ b/x/consensus/keeper/filters/unprocessed_filter.go
@@ -1,0 +1,7 @@
+package filters
+
+import "github.com/palomachain/paloma/x/consensus/types"
+
+func IsUnprocessed(msg types.QueuedSignedMessageI) bool {
+	return msg.GetPublicAccessData() == nil && msg.GetErrorData() == nil
+}

--- a/x/consensus/keeper/filters/unprocessed_filter_test.go
+++ b/x/consensus/keeper/filters/unprocessed_filter_test.go
@@ -1,7 +1,10 @@
 package filters
 
-import "testing"
-import "github.com/palomachain/paloma/x/consensus/types"
+import (
+	"testing"
+
+	"github.com/palomachain/paloma/x/consensus/types"
+)
 
 func Test_IsUnprocessed(t *testing.T) {
 	tests := []struct {

--- a/x/consensus/keeper/filters/unprocessed_filter_test.go
+++ b/x/consensus/keeper/filters/unprocessed_filter_test.go
@@ -1,0 +1,52 @@
+package filters
+
+import "testing"
+import "github.com/palomachain/paloma/x/consensus/types"
+
+func Test_IsUnprocessed(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  types.QueuedSignedMessageI
+		want bool
+	}{
+		{
+			name: "Test IsUnprocessed with nil public access data and nil error data",
+			msg: &types.QueuedSignedMessage{
+				PublicAccessData: nil,
+				ErrorData:        nil,
+			},
+			want: true,
+		},
+		{
+			name: "Test IsUnprocessed with non-nil public access data and nil error data",
+			msg: &types.QueuedSignedMessage{
+				PublicAccessData: &types.PublicAccessData{},
+				ErrorData:        nil,
+			},
+			want: false,
+		},
+		{
+			name: "Test IsUnprocessed with nil public access data and non-nil error data",
+			msg: &types.QueuedSignedMessage{
+				PublicAccessData: nil,
+				ErrorData:        &types.ErrorData{},
+			},
+			want: false,
+		},
+		{
+			name: "Test IsUnprocessed with non-nil public access data and non-nil error data",
+			msg: &types.QueuedSignedMessage{
+				PublicAccessData: &types.PublicAccessData{},
+				ErrorData:        &types.ErrorData{},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsUnprocessed(tt.msg); got != tt.want {
+				t.Errorf("IsUnprocessed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1760

# Background

This change prevents multiple messages from the same
    sender to be relayed in parallel, even by different
    relayers. This is a preliminary security step for
    pigeon feed to prevent exploitable race conditions.
    
There's also some house keeping and tidying around
    the filtering logic.


# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
