### PR TITLE
fix: message attestation with wrong sign data

### DIFF
--- a/x/consensus/keeper/concensus_keeper.go
+++ b/x/consensus/keeper/concensus_keeper.go
@@ -524,7 +524,8 @@ func (k Keeper) SetMessagePublicAccessData(
 		"chain-type", chainType,
 		"chain-reference-id", chainReferenceID,
 		"validator", valAddr.String(),
-		"public-access-data", hexutil.Encode(payload.Data)).
+		"public-access-data", hexutil.Encode(payload.Data),
+		"valset-id", payload.ValsetID).
 		Info("added message public access data.")
 
 	return nil

--- a/x/consensus/keeper/consensus/consensus.go
+++ b/x/consensus/keeper/consensus/consensus.go
@@ -358,7 +358,8 @@ func (c Queue) Remove(ctx context.Context, msgID uint64) error {
 		return nil
 	}
 
-	logger.WithFields("msg", json.RawMessage(jsonMsg)).
+	logger.WithFields("msg", json.RawMessage(jsonMsg),
+		"block_height", sdkCtx.BlockHeight()).
 		Info("Removed message from queue")
 
 	return nil

--- a/x/evm/keeper/attest.go
+++ b/x/evm/keeper/attest.go
@@ -41,7 +41,9 @@ func (k Keeper) attestMessageWrapper(ctx context.Context, q consensus.Queuer, ms
 
 	cacheCtx, writeCache := sdkCtx.CacheContext()
 	defer func() {
-		if retErr == nil {
+		// If there is no error, or we can't verify this transaction, we flush
+		// the context, so we never see it again
+		if retErr == nil || errors.Is(retErr, types.ErrEthTxNotVerified) {
 			writeCache()
 		}
 	}()

--- a/x/evm/types/turnstone_abi.go
+++ b/x/evm/types/turnstone_abi.go
@@ -189,6 +189,9 @@ func BuildCompassConsensus(
 					R: big.NewInt(0),
 					S: big.NewInt(0),
 				})
+			// This shouldn't matter, but in case it does, we guarantee we do it
+			// like Pigeon, so we add a zero signature
+			con.originalSignatures = append(con.originalSignatures, nil)
 		} else {
 			con.Signatures = append(con.Signatures,
 				Signature{


### PR DESCRIPTION
# Related Github tickets

- Closes https://github.com/VolumeFi/paloma/issues/1875

# Background

UpdateValset and SubmitLogicCall messages would fail to attest if:
* Some pigeons sign the message in the queue and a pigeon picks it up
* While this pigeon is relaying the message, some more pigeons sign it
* When we try to attest it, the SignData in paloma doesn't match the SignData of the original message, since more pigeons signed it since!

To fix it, we iterate through the message SignData and remove the last signature until we get a match, or there are no more signatures.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [ ] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
