### PR TITLE
fix: feegrant order in light node licenses

### DIFF
--- a/x/paloma/keeper/keeper.go
+++ b/x/paloma/keeper/keeper.go
@@ -366,6 +366,16 @@ func (k Keeper) CreateSaleLightNodeClientLicense(
 		return types.ErrInsufficientBalance
 	}
 
+	// First, we need to create the license
+	err = k.CreateLightNodeClientLicense(ctx, funder.String(),
+		clientAddr, coin, lightNodeSaleVestingMonths)
+	if err != nil {
+		return err
+	}
+
+	// Only then can we setup the feegrant, otherwise the account will already
+	// exist
+
 	allowance := &feegrantmodule.BasicAllowance{
 		SpendLimit: sdk.NewCoins(sdk.NewCoin(k.bondDenom, math.NewInt(1_000_000))),
 		Expiration: nil, // Unlimited time
@@ -376,13 +386,7 @@ func (k Keeper) CreateSaleLightNodeClientLicense(
 		return err
 	}
 
-	err = k.feegrantKeeper.GrantAllowance(ctx, feegranter.Account, acct, allowance)
-	if err != nil {
-		return err
-	}
-
-	return k.CreateLightNodeClientLicense(ctx, funder.String(),
-		clientAddr, coin, lightNodeSaleVestingMonths)
+	return k.feegrantKeeper.GrantAllowance(ctx, feegranter.Account, acct, allowance)
 }
 
 func (k Keeper) CreateLightNodeClientAccount(


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1865

# Background

We need to setup the license first, and only then do the feegrant, otherwise the account will already exist and fail the check.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
