### PR TITLE
fix: add chain to skyway nonces genesis

### DIFF
--- a/x/skyway/keeper/genesis.go
+++ b/x/skyway/keeper/genesis.go
@@ -201,6 +201,7 @@ func ExportGenesis(ctx context.Context, k Keeper) types.GenesisState {
 			LastSlashedBatchBlock: lastSlashedBlock,
 			LastTxPoolId:          lastTxPoolId,
 			LastBatchId:           lastBatchId,
+			ChainReferenceId:      chain,
 		})
 
 		attmap, attKeys, err := k.GetAttestationMapping(ctx, chain)

--- a/x/skyway/keeper/genesis_test.go
+++ b/x/skyway/keeper/genesis_test.go
@@ -187,3 +187,26 @@ func TestGenesisEmptyOptionalValues(t *testing.T) {
 	require.Empty(t, got.BridgeTaxes)
 	require.Empty(t, got.BridgeTransferLimits)
 }
+
+func TestGenesisSkywayNonces(t *testing.T) {
+	genesisState := types.GenesisState{
+		Params: types.DefaultParams(),
+		SkywayNonces: []types.SkywayNonces{
+			{
+				LastObservedNonce:     100,
+				LastSlashedBatchBlock: 101,
+				LastTxPoolId:          102,
+				LastBatchId:           103,
+				ChainReferenceId:      "test-chain",
+			},
+		},
+	}
+
+	input := CreateTestEnv(t)
+
+	InitGenesis(input.Context, input.SkywayKeeper, genesisState)
+	got := ExportGenesis(input.Context, input.SkywayKeeper)
+	require.NotNil(t, got)
+
+	require.Equal(t, genesisState.SkywayNonces, got.SkywayNonces)
+}


### PR DESCRIPTION
# Background

The field was missing, causing genesis to be exported with empty chain IDs. This would then cause a panic on import, as we try to set the last observed nonce to the same (empty) chain more than once.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
