### PR TITLE
fix: sort validators with same score by address

### DIFF
--- a/x/evm/keeper/msg_assigner.go
+++ b/x/evm/keeper/msg_assigner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	math "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -272,7 +273,9 @@ func rankValidators(ctx context.Context, validatorsInfos map[string]ValidatorInf
 		} else if a.score.LT(b.score) {
 			return 1
 		}
-		return 0
+
+		// If both validators have the same score, sort them by address
+		return strings.Compare(a.address, b.address)
 	})
 	return scoreSnapshot{
 		scores:      ranked,


### PR DESCRIPTION
# Related Github tickets

- Closes https://github.com/VolumeFi/paloma/issues/1929

# Background

We need to ensure validators are ordered even if they have the same score, otherwise the result might not be deterministic.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
