### PR TITLE
chore: add optional BUILD_TAGS to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,8 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=paloma \
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 
+build_tags += $(BUILD_TAGS)
+
 BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 
 build: go.sum


### PR DESCRIPTION
# Background

This allow us to customize the build, for instance to build with muslc instead of glibc.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [ ] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
