### PR TITLE
fix: Skyway query should filter estimates by chain ID

### DIFF
--- a/x/skyway/keeper/grpc_query.go
+++ b/x/skyway/keeper/grpc_query.go
@@ -399,6 +399,11 @@ func (k Keeper) LastPendingBatchForGasEstimation(ctx context.Context, req *types
 
 	found := false
 	err := k.IterateOutgoingTxBatches(sdk.UnwrapSDKContext(ctx), func(_ []byte, batch types.InternalOutgoingTxBatch) bool {
+		// Filter out batches that don't match the chain reference ID
+		if batch.ChainReferenceID != req.ChainReferenceId {
+			return false
+		}
+
 		estimate, err := k.GetBatchGasEstimate(sdk.UnwrapSDKContext(ctx), batch.BatchNonce, batch.TokenContract, req.Address)
 		if err != nil {
 			return false


### PR DESCRIPTION
# Testing completed

- [ ] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [ ] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
