### PR TITLE
chore: disable token relink before compass 2.0

### DIFF
--- a/x/evm/keeper/attest_test.go
+++ b/x/evm/keeper/attest_test.go
@@ -47,15 +47,15 @@ var (
 	})
 )
 
-type record struct {
-	denom string
-	erc20 string
-	chain string
-}
+// type record struct {
+// 	denom string
+// 	erc20 string
+// 	chain string
+// }
 
-func (r record) GetDenom() string            { return r.denom }
-func (r record) GetErc20() string            { return r.erc20 }
-func (r record) GetChainReferenceId() string { return r.chain }
+// func (r record) GetDenom() string            { return r.denom }
+// func (r record) GetErc20() string            { return r.erc20 }
+// func (r record) GetChainReferenceId() string { return r.chain }
 
 func TestKeeperGinkgo(t *testing.T) {
 	RegisterFailHandler(g.Fail)
@@ -114,7 +114,7 @@ var _ = g.Describe("attest router", func() {
 	var ctx sdk.Context
 	var q *consensusmocks.Queuer
 	var v *evmmocks.ValsetKeeper
-	var gk *evmmocks.SkywayKeeper
+	// var gk *evmmocks.SkywayKeeper
 	var consensukeeper *evmmocks.ConsensusKeeper
 	var mk *evmmocks.MetrixKeeper
 	var tk *evmmocks.TreasuryKeeper
@@ -147,7 +147,7 @@ var _ = g.Describe("attest router", func() {
 		ctx = _ctx
 		k = *kpr
 		v = ms.ValsetKeeper
-		gk = ms.SkywayKeeper
+		// gk = ms.SkywayKeeper
 		tk = ms.TreasuryKeeper
 		mk = ms.MetrixKeeper
 		consensukeeper = ms.ConsensusKeeper
@@ -571,9 +571,9 @@ var _ = g.Describe("attest router", func() {
 					})
 
 					g.When("target chain has no deployed ERC20 tokens", func() {
-						g.BeforeEach(func() {
-							gk.On("CastAllERC20ToDenoms", mock.Anything).Return(nil, nil)
-						})
+						// g.BeforeEach(func() {
+						// 	gk.On("CastAllERC20ToDenoms", mock.Anything).Return(nil, nil)
+						// })
 						g.It("removes deployment", func() {
 							setupChainSupport()
 							Expect(subject()).To(BeNil())
@@ -590,44 +590,44 @@ var _ = g.Describe("attest router", func() {
 						})
 					})
 
-					g.When("target chain has active ERC20 tokens deployed", func() {
-						g.BeforeEach(func() {
-							gk.On("CastAllERC20ToDenoms", mock.Anything).Return([]types.ERC20Record{
-								record{"denom", "address1", newChain.ChainReferenceID},
-								record{"denom2", "address2", newChain.ChainReferenceID},
-								record{"denom3", "address3", "unknown-chain"},
-							}, nil)
-						})
-						g.It("updates deployment", func() {
-							setupChainSupport()
-							Expect(subject()).To(BeNil())
-							v, key := k.getSmartContractDeploymentByContractID(ctx, uint64(1), newChain.GetChainReferenceID())
-							Expect(key).ToNot(BeNil())
-							Expect(v).ToNot(BeNil())
-							Expect(v.GetStatus()).To(BeEquivalentTo(types.SmartContractDeployment_WAITING_FOR_ERC20_OWNERSHIP_TRANSFER))
-							Expect(v.GetErc20Transfers()).To(BeEquivalentTo([]types.SmartContractDeployment_ERC20Transfer{
-								{
-									Denom:  "denom",
-									Erc20:  "address1",
-									MsgID:  10,
-									Status: types.SmartContractDeployment_ERC20Transfer_PENDING,
-								},
-								{
-									Denom:  "denom2",
-									Erc20:  "address2",
-									MsgID:  10,
-									Status: types.SmartContractDeployment_ERC20Transfer_PENDING,
-								},
-							}))
-						})
-						g.It("doesn't set the chain as active", func() {
-							setupChainSupport()
-							Expect(subject()).To(BeNil())
-							v, err := k.GetChainInfo(ctx, newChain.GetChainReferenceID())
-							Expect(err).To(BeNil())
-							Expect(v.GetActiveSmartContractID()).To(BeEquivalentTo(uint64(0)))
-						})
-					})
+					// g.When("target chain has active ERC20 tokens deployed", func() {
+					// 	g.BeforeEach(func() {
+					// 		gk.On("CastAllERC20ToDenoms", mock.Anything).Return([]types.ERC20Record{
+					// 			record{"denom", "address1", newChain.ChainReferenceID},
+					// 			record{"denom2", "address2", newChain.ChainReferenceID},
+					// 			record{"denom3", "address3", "unknown-chain"},
+					// 		}, nil)
+					// 	})
+					// 	g.It("updates deployment", func() {
+					// 		setupChainSupport()
+					// 		Expect(subject()).To(BeNil())
+					// 		v, key := k.getSmartContractDeploymentByContractID(ctx, uint64(1), newChain.GetChainReferenceID())
+					// 		Expect(key).ToNot(BeNil())
+					// 		Expect(v).ToNot(BeNil())
+					// 		Expect(v.GetStatus()).To(BeEquivalentTo(types.SmartContractDeployment_WAITING_FOR_ERC20_OWNERSHIP_TRANSFER))
+					// 		Expect(v.GetErc20Transfers()).To(BeEquivalentTo([]types.SmartContractDeployment_ERC20Transfer{
+					// 			{
+					// 				Denom:  "denom",
+					// 				Erc20:  "address1",
+					// 				MsgID:  10,
+					// 				Status: types.SmartContractDeployment_ERC20Transfer_PENDING,
+					// 			},
+					// 			{
+					// 				Denom:  "denom2",
+					// 				Erc20:  "address2",
+					// 				MsgID:  10,
+					// 				Status: types.SmartContractDeployment_ERC20Transfer_PENDING,
+					// 			},
+					// 		}))
+					// 	})
+					// 	g.It("doesn't set the chain as active", func() {
+					// 		setupChainSupport()
+					// 		Expect(subject()).To(BeNil())
+					// 		v, err := k.GetChainInfo(ctx, newChain.GetChainReferenceID())
+					// 		Expect(err).To(BeNil())
+					// 		Expect(v.GetActiveSmartContractID()).To(BeEquivalentTo(uint64(0)))
+					// 	})
+					// })
 				})
 
 				g.JustAfterEach(func() {

--- a/x/evm/keeper/attest_upload_smart_contract.go
+++ b/x/evm/keeper/attest_upload_smart_contract.go
@@ -4,12 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"strings"
-	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -101,15 +97,19 @@ func (a *uploadSmartContractAttester) attest(ctx sdk.Context, evidence *types.Tx
 		return err
 	}
 
-	records, err := a.k.Skyway.CastAllERC20ToDenoms(ctx)
-	if err != nil {
-		a.logger.WithError(err).Error("Failed to extract ERC20 records.")
-		return err
-	}
+	// TODO temporarily disable token relink so we can update to compass 2.0.
+	// We need to reenable this in v1.16.1 after compass 2.0 is deployed.
+	// See https://github.com/VolumeFi/paloma/issues/1891
+	//
+	// records, err := a.k.Skyway.CastAllERC20ToDenoms(ctx)
+	// if err != nil {
+	// 	a.logger.WithError(err).Error("Failed to extract ERC20 records.")
+	// 	return err
+	// }
 
-	if len(records) > 0 {
-		return a.startTokenRelink(ctx, deployment, records, newCompassAddr, smartContractID)
-	}
+	// if len(records) > 0 {
+	// 	return a.startTokenRelink(ctx, deployment, records, newCompassAddr, smartContractID)
+	// }
 
 	// If this is the first deployment on chain, it won't have a snapshot
 	// assigned to it. We need to assign it a snapshot, or we won't be able to
@@ -135,93 +135,93 @@ func (a *uploadSmartContractAttester) attest(ctx sdk.Context, evidence *types.Tx
 	return a.k.SetSmartContractAsActive(ctx, smartContractID, a.chainReferenceID)
 }
 
-func (a *uploadSmartContractAttester) startTokenRelink(
-	ctx sdk.Context,
-	deployment *types.SmartContractDeployment,
-	records []types.ERC20Record,
-	newCompassAddr common.Address,
-	smartContractID uint64,
-) error {
-	msgIDs := make([]uint64, 0, len(records))
-	transfers := make([]types.SmartContractDeployment_ERC20Transfer, 0, len(records))
-	erc20abi := `[{"inputs": [{"name": "_compass","type": "address"}],"name": "new_compass","outputs": [],"stateMutability": "nonpayable","type": "function"}]`
+// func (a *uploadSmartContractAttester) startTokenRelink(
+// 	ctx sdk.Context,
+// 	deployment *types.SmartContractDeployment,
+// 	records []types.ERC20Record,
+// 	newCompassAddr common.Address,
+// 	smartContractID uint64,
+// ) error {
+// 	msgIDs := make([]uint64, 0, len(records))
+// 	transfers := make([]types.SmartContractDeployment_ERC20Transfer, 0, len(records))
+// 	erc20abi := `[{"inputs": [{"name": "_compass","type": "address"}],"name": "new_compass","outputs": [],"stateMutability": "nonpayable","type": "function"}]`
 
-	for _, v := range records {
-		if v.GetChainReferenceId() != a.chainReferenceID {
-			continue
-		}
+// 	for _, v := range records {
+// 		if v.GetChainReferenceId() != a.chainReferenceID {
+// 			continue
+// 		}
 
-		payload, err := func() ([]byte, error) {
-			evm, err := abi.JSON(strings.NewReader(erc20abi))
-			if err != nil {
-				return nil, err
-			}
-			return evm.Pack("new_compass", newCompassAddr)
-		}()
-		if err != nil {
-			return err
-		}
+// 		payload, err := func() ([]byte, error) {
+// 			evm, err := abi.JSON(strings.NewReader(erc20abi))
+// 			if err != nil {
+// 				return nil, err
+// 			}
+// 			return evm.Pack("new_compass", newCompassAddr)
+// 		}()
+// 		if err != nil {
+// 			return err
+// 		}
 
-		// SLCs are usually always authored by either a contract on Paloma, or
-		// a specific validator. In this case, this is really a consensus operation
-		// without a singular governing entity. For the sake the established
-		// technological boundaries, we'll set the sender to the address of the
-		// validator that attested this message.
-		valAddr, err := sdk.ValAddressFromBech32(a.msg.GetAssignee())
-		if err != nil {
-			return fmt.Errorf("validator address from bech32: %w", err)
-		}
+// 		// SLCs are usually always authored by either a contract on Paloma, or
+// 		// a specific validator. In this case, this is really a consensus operation
+// 		// without a singular governing entity. For the sake the established
+// 		// technological boundaries, we'll set the sender to the address of the
+// 		// validator that attested this message.
+// 		valAddr, err := sdk.ValAddressFromBech32(a.msg.GetAssignee())
+// 		if err != nil {
+// 			return fmt.Errorf("validator address from bech32: %w", err)
+// 		}
 
-		sender := sdk.AccAddress(valAddr.Bytes())
+// 		sender := sdk.AccAddress(valAddr.Bytes())
 
-		modifiedPayload, err := injectSenderIntoPayload(make([]byte, 32), payload)
-		if err != nil {
-			return fmt.Errorf("inject zero padding to payload: %w", err)
-		}
+// 		modifiedPayload, err := injectSenderIntoPayload(make([]byte, 32), payload)
+// 		if err != nil {
+// 			return fmt.Errorf("inject zero padding to payload: %w", err)
+// 		}
 
-		ci, err := a.k.GetChainInfo(ctx, a.chainReferenceID)
-		if err != nil {
-			return fmt.Errorf("get chain info: %w", err)
-		}
+// 		ci, err := a.k.GetChainInfo(ctx, a.chainReferenceID)
+// 		if err != nil {
+// 			return fmt.Errorf("get chain info: %w", err)
+// 		}
 
-		msgID, err := a.k.AddSmartContractExecutionToConsensus(
-			ctx,
-			a.chainReferenceID,
-			string(ci.GetSmartContractUniqueID()),
-			&types.SubmitLogicCall{
-				HexContractAddress: v.GetErc20(),
-				Abi:                common.FromHex(""),
-				Payload:            modifiedPayload,
-				Deadline:           ctx.BlockTime().Add(10 * time.Minute).Unix(),
-				SenderAddress:      sender,
-				ExecutionRequirements: types.SubmitLogicCall_ExecutionRequirements{
-					EnforceMEVRelay: false,
-				},
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("execute job: %w", err)
-		}
+// 		msgID, err := a.k.AddSmartContractExecutionToConsensus(
+// 			ctx,
+// 			a.chainReferenceID,
+// 			string(ci.GetSmartContractUniqueID()),
+// 			&types.SubmitLogicCall{
+// 				HexContractAddress: v.GetErc20(),
+// 				Abi:                common.FromHex(""),
+// 				Payload:            modifiedPayload,
+// 				Deadline:           ctx.BlockTime().Add(10 * time.Minute).Unix(),
+// 				SenderAddress:      sender,
+// 				ExecutionRequirements: types.SubmitLogicCall_ExecutionRequirements{
+// 					EnforceMEVRelay: false,
+// 				},
+// 			},
+// 		)
+// 		if err != nil {
+// 			return fmt.Errorf("execute job: %w", err)
+// 		}
 
-		msgIDs = append(msgIDs, msgID)
-		transfers = append(transfers, types.SmartContractDeployment_ERC20Transfer{
-			Denom:  v.GetDenom(),
-			Erc20:  v.GetErc20(),
-			MsgID:  msgID,
-			Status: types.SmartContractDeployment_ERC20Transfer_PENDING,
-		})
-	}
+// 		msgIDs = append(msgIDs, msgID)
+// 		transfers = append(transfers, types.SmartContractDeployment_ERC20Transfer{
+// 			Denom:  v.GetDenom(),
+// 			Erc20:  v.GetErc20(),
+// 			MsgID:  msgID,
+// 			Status: types.SmartContractDeployment_ERC20Transfer_PENDING,
+// 		})
+// 	}
 
-	deployment.Erc20Transfers = transfers
-	if err := a.k.updateSmartContractDeployment(ctx, smartContractID, a.chainReferenceID, deployment); err != nil {
-		a.logger.WithError(err).Error("Failed to update smart contract deployment")
-		return err
-	}
+// 	deployment.Erc20Transfers = transfers
+// 	if err := a.k.updateSmartContractDeployment(ctx, smartContractID, a.chainReferenceID, deployment); err != nil {
+// 		a.logger.WithError(err).Error("Failed to update smart contract deployment")
+// 		return err
+// 	}
 
-	a.k.deploymentCache.Add(ctx, a.chainReferenceID, smartContractID, msgIDs...)
-	a.logger.Debug("attestation successful")
-	return nil
-}
+// 	a.k.deploymentCache.Add(ctx, a.chainReferenceID, smartContractID, msgIDs...)
+// 	a.logger.Debug("attestation successful")
+// 	return nil
+// }
 
 func (a *uploadSmartContractAttester) attemptRetry(ctx sdk.Context) {
 	contract := a.action


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1891

# Background

Even if we don't want to move test tokens, since we have them set, paloma will still try to move them. This will fail since (new) pigeon won't be compatible with (old) compass, so we need to disable this functionality before compass 2.0 is deployed and re-enable it again afterwards.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [ ] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
