### PR TITLE
fix: compass attestation with ERC20 tokens

### DIFF
--- a/x/evm/keeper/attest_test.go
+++ b/x/evm/keeper/attest_test.go
@@ -570,7 +570,7 @@ var _ = g.Describe("attest router", func() {
 
 					g.When("target chain has no deployed ERC20 tokens", func() {
 						g.BeforeEach(func() {
-							gk.On("CastAllERC20ToDenoms", mock.Anything).Return(nil, nil)
+							gk.On("CastChainERC20ToDenoms", mock.Anything, mock.Anything).Return(nil, nil)
 						})
 						g.It("removes deployment", func() {
 							setupChainSupport()
@@ -590,10 +590,9 @@ var _ = g.Describe("attest router", func() {
 
 					g.When("target chain has active ERC20 tokens deployed", func() {
 						g.BeforeEach(func() {
-							gk.On("CastAllERC20ToDenoms", mock.Anything).Return([]types.ERC20Record{
+							gk.On("CastChainERC20ToDenoms", mock.Anything, newChain.ChainReferenceID).Return([]types.ERC20Record{
 								record{"denom", "address1", newChain.ChainReferenceID},
 								record{"denom2", "address2", newChain.ChainReferenceID},
-								record{"denom3", "address3", "unknown-chain"},
 							}, nil)
 						})
 						g.It("updates deployment", func() {

--- a/x/evm/keeper/attest_upload_smart_contract.go
+++ b/x/evm/keeper/attest_upload_smart_contract.go
@@ -101,7 +101,8 @@ func (a *uploadSmartContractAttester) attest(ctx sdk.Context, evidence *types.Tx
 		return err
 	}
 
-	records, err := a.k.Skyway.CastAllERC20ToDenoms(ctx)
+	// Get the ERC20 tokens just for this chain
+	records, err := a.k.Skyway.CastChainERC20ToDenoms(ctx, a.chainReferenceID)
 	if err != nil {
 		a.logger.WithError(err).Error("Failed to extract ERC20 records.")
 		return err
@@ -210,6 +211,13 @@ func (a *uploadSmartContractAttester) startTokenRelink(
 			MsgID:  msgID,
 			Status: types.SmartContractDeployment_ERC20Transfer_PENDING,
 		})
+	}
+
+	// This shouldn't be needed anymore, since we query the ERC20 tokens for
+	// this specific chain. However, just to make double sure, we check the
+	// transfers. If there's none, just set the contract to active.
+	if len(transfers) == 0 {
+		return a.k.SetSmartContractAsActive(ctx, smartContractID, a.chainReferenceID)
 	}
 
 	deployment.Erc20Transfers = transfers

--- a/x/evm/types/expected_keepers.go
+++ b/x/evm/types/expected_keepers.go
@@ -61,6 +61,7 @@ type ERC20Record interface {
 type SkywayKeeper interface {
 	GetLastObservedSkywayNonce(ctx context.Context, chainReferenceID string) (uint64, error)
 	CastAllERC20ToDenoms(ctx context.Context) ([]ERC20Record, error)
+	CastChainERC20ToDenoms(ctx context.Context, chainReferenceID string) ([]ERC20Record, error)
 }
 
 //go:generate mockery --name=MetrixKeeper

--- a/x/evm/types/mocks/SkywayKeeper.go
+++ b/x/evm/types/mocks/SkywayKeeper.go
@@ -44,6 +44,36 @@ func (_m *SkywayKeeper) CastAllERC20ToDenoms(ctx context.Context) ([]types.ERC20
 	return r0, r1
 }
 
+// CastChainERC20ToDenoms provides a mock function with given fields: ctx, chainReferenceID
+func (_m *SkywayKeeper) CastChainERC20ToDenoms(ctx context.Context, chainReferenceID string) ([]types.ERC20Record, error) {
+	ret := _m.Called(ctx, chainReferenceID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CastChainERC20ToDenoms")
+	}
+
+	var r0 []types.ERC20Record
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]types.ERC20Record, error)); ok {
+		return rf(ctx, chainReferenceID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) []types.ERC20Record); ok {
+		r0 = rf(ctx, chainReferenceID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]types.ERC20Record)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, chainReferenceID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetLastObservedSkywayNonce provides a mock function with given fields: ctx, chainReferenceID
 func (_m *SkywayKeeper) GetLastObservedSkywayNonce(ctx context.Context, chainReferenceID string) (uint64, error) {
 	ret := _m.Called(ctx, chainReferenceID)
@@ -77,8 +107,7 @@ func (_m *SkywayKeeper) GetLastObservedSkywayNonce(ctx context.Context, chainRef
 func NewSkywayKeeper(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *SkywayKeeper {
+}) *SkywayKeeper {
 	mock := &SkywayKeeper{}
 	mock.Mock.Test(t)
 

--- a/x/skyway/keeper/cosmos-originated.go
+++ b/x/skyway/keeper/cosmos-originated.go
@@ -83,6 +83,25 @@ func (k Keeper) CastAllERC20ToDenoms(ctx context.Context) ([]evmtypes.ERC20Recor
 	return cast, nil
 }
 
+func (k Keeper) CastChainERC20ToDenoms(
+	ctx context.Context,
+	chainReferenceID string,
+) ([]evmtypes.ERC20Record, error) {
+	all, err := k.GetAllERC20ToDenoms(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cast := make([]evmtypes.ERC20Record, 0, len(all))
+	for _, v := range all {
+		if v.GetChainReferenceId() == chainReferenceID {
+			cast = append(cast, v)
+		}
+	}
+
+	return cast, nil
+}
+
 func (k Keeper) setDenomToERC20(ctx context.Context, chainReferenceId, denom string, tokenContract types.EthAddress) error {
 	store := k.GetStore(ctx, types.StoreModulePrefix)
 


### PR DESCRIPTION
# Related Github tickets

- Closes https://github.com/VolumeFi/paloma/issues/1953

# Background

When some chain has ERC20 tokens deployed, compass upgrades would be stuck on chains that do not have tokens. Now we only query deployed tokens for the specific chain currently being iterated.

NOTE: After deploying this change, we have to manually remove any stuck compass upgrade. It should redeploy automatically afterwards.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
