### PR TITLE
fix: set senderAddress in SLCs from CW

### DIFF
--- a/x/scheduler/keeper/wasm_handler.go
+++ b/x/scheduler/keeper/wasm_handler.go
@@ -60,7 +60,7 @@ func (k Keeper) ExecuteWasmJobEventListener() wasmutil.MessengerFnc {
 			return nil, nil, whoops.Wrap(err, types.ErrWasmExecuteMessageNotValid)
 		}
 
-		msgID, err := k.ExecuteJob(ctx, executeMsg.JobID, executeMsg.Payload, nil, contractAddr)
+		msgID, err := k.ExecuteJob(ctx, executeMsg.JobID, executeMsg.Payload, contractAddr, contractAddr)
 		if err != nil {
 			logger.WithError(err).Error("Failed to trigger job execution.")
 			return nil, nil, err


### PR DESCRIPTION
# Background

SLCs generated from CosmWasm contracts were setting the `ContractAddress` field, but not the `SenderAddress` field. This is an issue for pigeon feed. We now set both fields on these calls.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
