### PR TITLE
fix: prevent stuck SLCs waiting for valset

### DIFF
--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -183,6 +183,10 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	am.keeper.TryDeployingLastCompassContractToAllChains(sdkCtx)
 
+	// Add valset updates to queue if we have SLCs in the queue and a valset
+	// mismatch. This should prevent SLCs from getting stuck.
+	am.keeper.AddJustInTimeValsetUpdates(sdkCtx)
+
 	if sdkCtx.BlockHeight()%300 == 0 {
 		if err := am.scheduleExternalBalances(sdkCtx); err != nil {
 			liblog.FromSDKLogger(sdkCtx.Logger()).WithError(err).


### PR DESCRIPTION
# Related Github tickets

- Closes https://github.com/VolumeFi/paloma/issues/1040

# Background

If a JIT ValsetUpdate fails, it can lead to SLC messages being stuck. In order to overcome this, we set a watcher on the end blocker to insert new ValsetUpdates when needed if there is an SLC message in the queue (or UploadUserSmartContract message).

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
