### PR TITLE
fix: set light node sale amount in GRAIN

### DIFF
--- a/x/paloma/keeper/keeper.go
+++ b/x/paloma/keeper/keeper.go
@@ -329,7 +329,9 @@ func (k Keeper) CreateSaleLightNodeClientLicense(
 	clientAddr string,
 	amount math.Int,
 ) error {
-	coin := sdk.NewCoin(k.bondDenom, amount)
+	// The amount will be set in GRAIN, but we want it here in uGRAIN, so we
+	// need to multiply by 1_000_000
+	coin := sdk.NewCoin(k.bondDenom, amount.Mul(math.NewInt(1_000_000)))
 
 	feegranter, err := k.LightNodeClientFeegranter(ctx)
 	if err != nil {

--- a/x/paloma/keeper/keeper_test.go
+++ b/x/paloma/keeper/keeper_test.go
@@ -219,7 +219,10 @@ func TestCreateSaleLightNodeClientLicense(t *testing.T) {
 	amount := math.NewInt(100)
 	license := &types.LightNodeClientLicense{
 		ClientAddress: clientAddr,
-		Amount:        sdk.Coin{Amount: amount, Denom: testBondDenom},
+		Amount: sdk.Coin{
+			Amount: amount.Mul(math.NewInt(1_000_000)),
+			Denom:  testBondDenom,
+		},
 		VestingMonths: 24,
 	}
 


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2105

# Background

Fix the units on the node sale amounts.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [ ] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
