### PR TITLE
feat: adapt gas estimation to reduce 120% safety buffer

### DIFF
--- a/util/libcons/consensus.go
+++ b/util/libcons/consensus.go
@@ -226,15 +226,12 @@ func (c ConsensusChecker) VerifyGasEstimates(ctx context.Context, p liblog.LogPr
 	}
 
 	// Retrieve the median value of the gas estimates and
-	// multiply value by 1.2 to allow for some security margin
 	winner := palomath.Median(estimateValues)
 	logger.WithFields("gas-estimate", winner).Debug("Built median value of gas estimates.")
 
 	if winner == 0 {
 		return 0, fmt.Errorf("gas estimate is zero")
 	}
-
-	winner = (winner * 6) / 5
 
 	logger.WithFields("gas-estimate", winner).Debug("Adding security margin.")
 	return winner, nil

--- a/util/libcons/consensus.go
+++ b/util/libcons/consensus.go
@@ -233,6 +233,5 @@ func (c ConsensusChecker) VerifyGasEstimates(ctx context.Context, p liblog.LogPr
 		return 0, fmt.Errorf("gas estimate is zero")
 	}
 
-	logger.WithFields("gas-estimate", winner).Debug("Adding security margin.")
 	return winner, nil
 }

--- a/x/consensus/keeper/estimate_test.go
+++ b/x/consensus/keeper/estimate_test.go
@@ -116,9 +116,9 @@ func Test_CheckAndProcessEstimatedMessages(t *testing.T) {
 				}
 
 				r.NotNil(slc.Fees)
-				r.Equal(uint64(31500), slc.Fees.RelayerFee, "relayer fee: got %d", slc.Fees.RelayerFee)
-				r.Equal(uint64(9450), slc.Fees.CommunityFee, "community fee: got %d", slc.Fees.CommunityFee)
-				r.Equal(uint64(315), slc.Fees.SecurityFee, "security fee: got %d", slc.Fees.SecurityFee)
+				r.Equal(uint64(26250), slc.Fees.RelayerFee, "relayer fee: got %d", slc.Fees.RelayerFee)
+				r.Equal(uint64(7875), slc.Fees.CommunityFee, "community fee: got %d", slc.Fees.CommunityFee)
+				r.Equal(uint64(263), slc.Fees.SecurityFee, "security fee: got %d", slc.Fees.SecurityFee)
 				return true
 			},
 		},
@@ -142,9 +142,9 @@ func Test_CheckAndProcessEstimatedMessages(t *testing.T) {
 				}
 
 				r.NotNil(usc.Fees)
-				r.Equal(uint64(31500), usc.Fees.RelayerFee, "relayer fee: got %d", usc.Fees.RelayerFee)
-				r.Equal(uint64(9450), usc.Fees.CommunityFee, "community fee: got %d", usc.Fees.CommunityFee)
-				r.Equal(uint64(315), usc.Fees.SecurityFee, "security fee: got %d", usc.Fees.SecurityFee)
+				r.Equal(uint64(26250), usc.Fees.RelayerFee, "relayer fee: got %d", usc.Fees.RelayerFee)
+				r.Equal(uint64(7875), usc.Fees.CommunityFee, "community fee: got %d", usc.Fees.CommunityFee)
+				r.Equal(uint64(263), usc.Fees.SecurityFee, "security fee: got %d", usc.Fees.SecurityFee)
 				return true
 			},
 		},
@@ -205,7 +205,7 @@ func Test_CheckAndProcessEstimatedMessages(t *testing.T) {
 			m, err := q.GetMsgByID(ctx, mid)
 			r.NoError(err)
 			r.Len(m.GetGasEstimates(), 7)
-			r.Equal(uint64(25200), m.GetGasEstimate())
+			r.Equal(uint64(21000), m.GetGasEstimate())
 			tc.slcCheck(getMsg(mid), r, true)
 		})
 	}

--- a/x/skyway/abci_test.go
+++ b/x/skyway/abci_test.go
@@ -367,7 +367,7 @@ func TestGasEstimation(t *testing.T) {
 
 	gotBatch, err = input.SkywayKeeper.GetOutgoingTXBatch(ctx, b.TokenContract, b.BatchNonce)
 	require.NoError(t, err)
-	require.Equal(t, uint64(25200), gotBatch.GasEstimate)
+	require.Equal(t, uint64(21000), gotBatch.GasEstimate, "want: %d, got: %d", uint64(20000), gotBatch.GasEstimate)
 
 	// Removing those again to avoid invariant issues due to dummy signatures
 	err = input.SkywayKeeper.CancelOutgoingTXBatch(ctx, gotBatch.TokenContract, gotBatch.BatchNonce)


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2089

# Background

This change addresses the inflated estimate that used to include a `1.2` modifier applied to the limit in as a security margin. 

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
