### PR TITLE
chore: update skyway validator nonces

### DIFF
--- a/x/skyway/keeper/attestation.go
+++ b/x/skyway/keeper/attestation.go
@@ -164,6 +164,13 @@ func (k Keeper) TryAttestation(ctx context.Context, att *types.Attestation) erro
 					return err
 				}
 
+				// Update all validator nonces to the claim nonce that was just
+				// processed
+				err = k.updateValidatorNoncesIfHigher(ctx, claim.GetChainReferenceId(), claim.GetSkywayNonce())
+				if err != nil {
+					return err
+				}
+
 				break
 			}
 		}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2159

# Background

When a claim is set to observed, update all validator nonces if they have a lower last observed nonce.

NOTE: This only takes effect when a claim is successfully attested to. The validators currently stuck will remain on their current nonces until a claim is processed. To get them unstuck, we need https://github.com/VolumeFi/paloma/issues/2160

# Testing completed

- [ ] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
