### PR TITLE
feat: add authz module

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
 	consensustypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
@@ -153,6 +154,17 @@ func (app *App) RegisterUpgradeHandlers(semverVersion string) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Added: []string{
 				palomamoduletypes.StoreKey,
+			},
+		}
+
+		// configure store loader that checks if version == upgradeHeight and applies store upgrades
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
+
+	if upgradeInfo.Name == "v2.2.1" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{
+				authzkeeper.StoreKey,
 			},
 		}
 


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2163

# Background

Add the authz module to paloma, so we can grant authorizations to delegate and claim rewards.

NOTE: this adds a migration assuming the next release is going to be 2.2.1

# Testing completed

- [ ] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
