### PR TITLE
chore: update validator nonces in endblocker

### DIFF
--- a/x/skyway/abci.go
+++ b/x/skyway/abci.go
@@ -42,6 +42,14 @@ func EndBlocker(ctx context.Context, k keeper.Keeper, cc *libcons.ConsensusCheck
 		if err != nil {
 			logger.WithError(err).Warn("Failed to prune attestations.")
 		}
+
+		// Update all validator nonces to the latest observed nonce, if suitable
+		// This makes sure validators don't get stuck waiting for events they
+		// can't get from the RPC, even though these events are already observed
+		err = k.UpdateValidatorNoncesToLatest(ctx, v)
+		if err != nil {
+			logger.WithError(err).Warn("Failed to update validator nonces.")
+		}
 	}
 
 	err = processGasEstimates(ctx, k, cc)

--- a/x/skyway/abci.go
+++ b/x/skyway/abci.go
@@ -14,8 +14,12 @@ import (
 	"github.com/palomachain/paloma/x/skyway/types"
 )
 
+const updateValidatorNoncesPeriod = 50
+
 // EndBlocker is called at the end of every block
 func EndBlocker(ctx context.Context, k keeper.Keeper, cc *libcons.ConsensusChecker) {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
 	logger := liblog.FromKeeper(ctx, k).WithComponent("skyway-endblocker")
 	defer func() {
 		if r := recover(); r != nil {
@@ -43,12 +47,15 @@ func EndBlocker(ctx context.Context, k keeper.Keeper, cc *libcons.ConsensusCheck
 			logger.WithError(err).Warn("Failed to prune attestations.")
 		}
 
-		// Update all validator nonces to the latest observed nonce, if suitable
-		// This makes sure validators don't get stuck waiting for events they
-		// can't get from the RPC, even though these events are already observed
-		err = k.UpdateValidatorNoncesToLatest(ctx, v)
-		if err != nil {
-			logger.WithError(err).Warn("Failed to update validator nonces.")
+		if sdkCtx.BlockHeight()%updateValidatorNoncesPeriod == 0 {
+			// Update all validator nonces to the latest observed nonce, if
+			// suitable This makes sure validators don't get stuck waiting for
+			// events they can't get from the RPC, even though these events are
+			// already observed
+			err = k.UpdateValidatorNoncesToLatest(ctx, v)
+			if err != nil {
+				logger.WithError(err).Warn("Failed to update validator nonces.")
+			}
 		}
 	}
 

--- a/x/skyway/keeper/attestation.go
+++ b/x/skyway/keeper/attestation.go
@@ -165,13 +165,6 @@ func (k Keeper) TryAttestation(ctx context.Context, att *types.Attestation) erro
 					return err
 				}
 
-				// Update all validator nonces to the claim nonce that was just
-				// processed
-				err = k.updateValidatorNoncesIfHigher(ctx, claim.GetChainReferenceId(), claim.GetSkywayNonce())
-				if err != nil {
-					return err
-				}
-
 				break
 			}
 		}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2160

# Background

The way it was before, we would need a claim to be observed so validators would be updated. By doing it in the endblocker, we validators are always up-to-date.

This should prevent a situation where the last claim is 19, the last observed nonce is 18, but validators are stuck on nonce 17. They would receive a list of block events with the block of nonce 19 (latest unobserved) but would be unable to claim it, since skyway would expect them to submit a claim for nonce 18 instead.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
