### PR TITLE
feat: add fee skipping

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1057,6 +1057,7 @@ func New(
 			SignModeHandler: txConfig.SignModeHandler(),
 			FeegrantKeeper:  app.FeeGrantKeeper,
 			SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
+			TxFeeChecker:    palomamodule.TxFeeSkipper,
 		},
 	)
 	if err != nil {

--- a/x/paloma/ante.go
+++ b/x/paloma/ante.go
@@ -143,3 +143,10 @@ func (d VerifyAuthorisedSignatureDecorator) AnteHandle(ctx sdk.Context, tx sdk.T
 
 	return next(ctx, tx, simulate)
 }
+
+// TxFeeSkipper is a TxFeeChecker that skips fee deduction entirely.
+// Every transaction will be considered valid and no fee will be deducted.
+// This also means that every transaction will be prioritized equally.
+func TxFeeSkipper(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
+	return sdk.NewCoins(), 42, nil
+}

--- a/x/paloma/ante_test.go
+++ b/x/paloma/ante_test.go
@@ -265,3 +265,37 @@ func Test_VerifyAuthorisedSignatureDecorator(t *testing.T) {
 		})
 	}
 }
+
+func Test_TxFeeSkipper(t *testing.T) {
+	t.Run("with no msgs in tx", func(t *testing.T) {
+		ctx := sdk.NewContext(nil, tmproto.Header{}, false, log.NewNopLogger())
+		tx := &tx{
+			msgs: []sdk.Msg{
+				&types.MsgAddStatusUpdate{
+					Status: "bar",
+					Level:  0,
+					Metadata: vtypes.MsgMetadata{
+						Creator: "foo",
+						Signers: []string{"foo"},
+					},
+				},
+			},
+		}
+		fee, p, err := paloma.TxFeeSkipper(ctx, tx)
+
+		require.Equal(t, sdk.Coins{}, fee)
+		require.True(t, fee.IsZero())
+		require.Equal(t, int64(42), p)
+		require.NoError(t, err)
+	})
+
+	t.Run("with nil tx", func(t *testing.T) {
+		ctx := sdk.NewContext(nil, tmproto.Header{}, false, log.NewNopLogger())
+		fee, p, err := paloma.TxFeeSkipper(ctx, nil)
+
+		require.Equal(t, sdk.Coins{}, fee)
+		require.True(t, fee.IsZero())
+		require.Equal(t, int64(42), p)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2466

# Background

This change introduces as custom `TxFeeChecker` implementation, which simply returns an empty fee for every transaction, as well as a constant priority.

Merging this change will lead to an equal transaction prioritization across Paloma, without the option to incentivize validators to include a transaction in an earlier block.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
