### PR TITLE
chore: enable optimistic execution

### DIFF
--- a/cmd/palomad/commands.go
+++ b/cmd/palomad/commands.go
@@ -9,6 +9,7 @@ import (
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmcli "github.com/CosmWasm/wasmd/x/wasm/client/cli"
 	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/debug"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -80,6 +81,7 @@ func newApp(
 	appOpts servertypes.AppOptions,
 ) servertypes.Application {
 	baseappOptions := server.DefaultBaseappOptions(appOpts)
+	baseappOptions = append(baseappOptions, baseapp.SetOptimisticExecution())
 
 	return app.New(
 		logger, db, traceStore, true,


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1162

# Background

Enforces optimistic execution across all nodes. PTN tests are looking good, but our mileage may vary depending on cross chain chatter.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
