### PR TITLE
chore: remove legacy binding field

### DIFF
--- a/x/scheduler/bindings/legacy.go
+++ b/x/scheduler/bindings/legacy.go
@@ -29,7 +29,6 @@ type customLegacyMessenger struct {
 
 type executeJobWasmEvent struct {
 	JobID   string `json:"job_id"`
-	Sender  string `json:"sender"`
 	Payload []byte `json:"payload"`
 }
 


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2497

# Background

Removes an unused field from the scheduler module legacy bindings. Additional fields are discarded, so backwards compatibility is not broken here.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
