### PR TITLE
fix: wasm binding integrations

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1342,7 +1342,7 @@ func buildWasmMessageDecorator(
 	srv := schedulermodulekeeper.NewMsgServerImpl(scheduler)
 	skwSrv := skywaymodulekeeper.NewMsgServerImpl(*skyway)
 
-	return libwasm.NewMessenger(
+	return libwasm.NewRouterMessageDecorator(
 		log,
 		schedulerbindings.NewLegacyMessenger(scheduler),
 		schedulerbindings.NewMessenger(scheduler, srv),

--- a/util/libwasm/plugin_test.go
+++ b/util/libwasm/plugin_test.go
@@ -16,29 +16,28 @@ import (
 )
 
 // MockMessenger is a mock implementation of wasmkeeper.Messenger
-type MockMessenger struct {
+type MockMessenger[T any] struct {
 	mock.Mock
 }
 
-func (m *MockMessenger) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) ([]sdk.Event, [][]byte, [][]*codectypes.Any, error) {
+func (m *MockMessenger[T]) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg T) ([]sdk.Event, [][]byte, [][]*codectypes.Any, error) {
 	args := m.Called(ctx, contractAddr, contractIBCPortID, msg)
 	return args.Get(0).([]sdk.Event), args.Get(1).([][]byte), args.Get(2).([][]*codectypes.Any), args.Error(3)
 }
 
 func TestDispatchMsg(t *testing.T) {
-	// Setup
 	ctx := sdk.Context{}
 	contractAddr := sdk.AccAddress([]byte("test_address"))
 	contractIBCPortID := "test_port"
 
 	logger := log.NewNopLogger()
-	mockScheduler := new(MockMessenger)
-	mockSkyway := new(MockMessenger)
-	mockTokenFactory := new(MockMessenger)
-	mockLegacyFallback := new(MockMessenger)
-	mockWrapped := new(MockMessenger)
+	mockScheduler := new(MockMessenger[schedulerbindings.Message])
+	mockSkyway := new(MockMessenger[skywaybindings.Message])
+	mockTokenFactory := new(MockMessenger[tfbindings.Message])
+	mockLegacyFallback := new(MockMessenger[wasmvmtypes.CosmosMsg])
+	mockWrapped := new(MockMessenger[wasmvmtypes.CosmosMsg])
 
-	h := Messenger{
+	h := router{
 		log:            logger,
 		legacyFallback: mockLegacyFallback,
 		scheduler:      mockScheduler,

--- a/x/skyway/bindings/msg_plugin.go
+++ b/x/skyway/bindings/msg_plugin.go
@@ -2,13 +2,11 @@ package bindings
 
 import (
 	"context"
-	"encoding/json"
 
 	sdkerrors "cosmossdk.io/errors"
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-	wasmvmtypes "github.com/CosmWasm/wasmvm/v2/types"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/palomachain/paloma/v2/util/libwasm"
 	bindingstypes "github.com/palomachain/paloma/v2/x/skyway/bindings/types"
 	skywaytypes "github.com/palomachain/paloma/v2/x/skyway/types"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -24,84 +22,85 @@ type customMessenger struct {
 	k SkywayMsgServer
 }
 
-var _ wasmkeeper.Messenger = (*customMessenger)(nil)
+var _ libwasm.Messenger[bindingstypes.Message] = (*customMessenger)(nil)
 
-func NewMessenger(k SkywayMsgServer) wasmkeeper.Messenger {
+func NewMessenger(k SkywayMsgServer) libwasm.Messenger[bindingstypes.Message] {
 	return &customMessenger{
 		k: k,
 	}
 }
 
-func (m *customMessenger) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) ([]sdk.Event, [][]byte, [][]*codectypes.Any, error) {
-	if msg.Custom != nil {
-		var contractMsg bindingstypes.Message
-		if err := json.Unmarshal(msg.Custom, &contractMsg); err != nil {
-			return nil, nil, nil, sdkerrors.Wrap(err, "skyway msg")
-		}
-
-		switch {
-		case contractMsg.SetErc20ToDenom != nil:
-		case contractMsg.SendTx != nil:
-		case contractMsg.CancelTx != nil:
-			return nil, nil, nil, nil
-		}
+func (m *customMessenger) DispatchMsg(
+	ctx sdk.Context,
+	contractAddr sdk.AccAddress,
+	contractIBCPortID string,
+	contractMsg bindingstypes.Message,
+) ([]sdk.Event, [][]byte, [][]*codectypes.Any, error) {
+	switch {
+	case contractMsg.SetErc20ToDenom != nil:
+		return handleSetErc20ToDenom(ctx, m.k, contractAddr, contractMsg.SetErc20ToDenom)
+	case contractMsg.SendTx != nil:
+		return sendTx(ctx, m.k, contractAddr, contractMsg.SendTx)
+	case contractMsg.CancelTx != nil:
+		return cancelTx(ctx, m.k, contractAddr, contractMsg.CancelTx)
 	}
-	return nil, nil, nil, nil
+
+	return nil, nil, nil, libwasm.ErrUnrecognizedMessage
 }
 
-func sendTx(ctx sdk.Context, k SkywayMsgServer, sender sdk.AccAddress, msg bindingstypes.SendTx) error {
+func sendTx(ctx sdk.Context, k SkywayMsgServer, sender sdk.AccAddress, msg *bindingstypes.SendTx) ([]sdk.Event, [][]byte, [][]*codectypes.Any, error) {
 	if err := msg.ValidateBasic(); err != nil {
-		return sdkerrors.Wrap(err, "validation failed")
+		return nil, nil, nil, sdkerrors.Wrap(err, "validation failed")
 	}
 
 	dest, err := skywaytypes.NewEthAddress(msg.RemoteChainDestinationAddress)
 	if err != nil {
-		return sdkerrors.Wrap(err, "invalid eth address")
+		return nil, nil, nil, sdkerrors.Wrap(err, "invalid eth address")
 	}
 
 	amount, err := sdk.ParseCoinsNormalized(msg.Amount)
 	if err != nil {
-		return sdkerrors.Wrap(err, "amount")
+		return nil, nil, nil, sdkerrors.Wrap(err, "amount")
 	}
 
 	req := skywaytypes.NewMsgSendToRemote(sender, *dest, amount[0], msg.ChainReferenceId)
 	_, err = k.SendToRemote(ctx, req)
 	if err != nil {
-		return sdkerrors.Wrap(err, "failed to dispatch message")
+		return nil, nil, nil, sdkerrors.Wrap(err, "failed to dispatch message")
 	}
 
-	return nil
+	return nil, nil, nil, nil
 }
 
-func cancelTx(ctx sdk.Context, k SkywayMsgServer, sender sdk.AccAddress, msg bindingstypes.CancelTx) error {
+func cancelTx(ctx sdk.Context, k SkywayMsgServer, sender sdk.AccAddress, msg *bindingstypes.CancelTx) ([]sdk.Event, [][]byte, [][]*codectypes.Any, error) {
 	if err := msg.ValidateBasic(); err != nil {
-		return sdkerrors.Wrap(err, "validation failed")
+		return nil, nil, nil, sdkerrors.Wrap(err, "validation failed")
 	}
 
 	req := skywaytypes.NewMsgCancelSendToRemote(sender, msg.TransactionId)
 	_, err := k.CancelSendToRemote(ctx, req)
 	if err != nil {
-		return sdkerrors.Wrap(err, "failed to dispatch message")
+		return nil, nil, nil, sdkerrors.Wrap(err, "failed to dispatch message")
 	}
 
-	return nil
+	return nil, nil, nil, nil
 }
 
-func handleSetErc20ToDenom(ctx sdk.Context, k SkywayMsgServer, sender sdk.AccAddress, msg bindingstypes.SetErc20ToDenom) error {
+func handleSetErc20ToDenom(ctx sdk.Context, k SkywayMsgServer, sender sdk.AccAddress, msg *bindingstypes.SetErc20ToDenom) ([]sdk.Event, [][]byte, [][]*codectypes.Any, error) {
 	if err := msg.ValidateBasic(); err != nil {
-		return sdkerrors.Wrap(err, "validation failed")
+		return nil, nil, nil, sdkerrors.Wrap(err, "validation failed")
 	}
 
 	erc20, err := skywaytypes.NewEthAddress(msg.Erc20Address)
 	if err != nil {
-		return sdkerrors.Wrap(err, "invalid eth address")
+		return nil, nil, nil, sdkerrors.Wrap(err, "invalid eth address")
 	}
 
 	req := skywaytypes.NewMsgSetERC20ToTokenDenom(sender, *erc20, msg.ChainReferenceId, msg.TokenDenom)
 	_, err = k.SetERC20ToTokenDenom(ctx, req)
 	if err != nil {
-		return sdkerrors.Wrap(err, "failed to dispatch message")
+		return nil, nil, nil, sdkerrors.Wrap(err, "failed to dispatch message")
 	}
 
-	return nil
+	return nil, nil, nil, nil
 }


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2531

# Background

This change addresses a bug in the way custom `wasm` messages are parsed and routed to target modules. 

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
