### PR TITLE
ci: increase Go version

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: '1.23.5'
           cache: false
       - name: Go lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Go lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59.1
+          version: v1.63.4
           args: --verbose
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23.5'
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
   release:
     permissions:
       contents: write # for goreleaser/goreleaser-action to create a GitHub release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # stick with older LTS release for continued debian support
     steps:
       - uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.2'
+          go-version: '1.23.5'
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Create release

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  go: '1.22'
+  go: '1.23.5'
   issues-exit-code: 1
   timeout: 10m
   modules-download-mode: readonly

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,3 +39,4 @@ issues:
     - G101 # Potential hardcoded credentials
     - G114 # Use of net/http serve function that has no support for setting timeouts
     - G113 # Potential uncontrolled memory consumption in Rat.SetString - this is fixed since go 1.17.7
+    - G115 # We do this everywhere (I suppose if it overflows, at least it will for everyone...)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ###########################
 ####     Base image    ####
 ###########################
-FROM golang:1.22-buster AS base
+FROM golang:1.23-buster AS base
 
 # TODO add non-root user
 LABEL org.opencontainers.image.authors="christian@volume.finance"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TM_VERSION           := $(shell go list -m github.com/cometbft/cometbft | sed 's
 DOCKER               := $(shell which docker)
 PROJECT_NAME         := paloma
 HTTPS_GIT            := https://github.com/palomachain/paloma.git
-GOLANGCILINT_VERSION := 1.51.2
+GOLANGCILINT_VERSION := 1.63.4
 
 ###############################################################################
 ##                                  Version                                  ##

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ sudo chmod +x /usr/local/bin/palomad
 
 ### To build palomad using latest release
 
+> [!IMPORTANT]  
+> Always make sure you're building against the latest released version of Go.
+
 ```shell
 git clone https://github.com/palomachain/paloma.git
 cd paloma

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/palomachain/paloma/v2
 
-go 1.22.2
+go 1.23.5
 
 require (
 	cosmossdk.io/errors v1.0.1


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2540

# Background

- Lock the CI runner versions
- Upgrade to the latest released version of Go

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
