### PR TITLE
fix: prevent mapping multiple denoms to same ERC20

### DIFF
--- a/x/skyway/keeper/msg_server.go
+++ b/x/skyway/keeper/msg_server.go
@@ -492,6 +492,15 @@ func (k *msgServer) SetERC20ToTokenDenom(ctx context.Context, msg *types.MsgSetE
 		return nil, sdkerrors.Wrap(types.ErrUnauthorized, "missing token admin permission")
 	}
 
+	d, err := k.GetDenomOfERC20(ctx, ci.ChainReferenceID, *erc20)
+	if err != nil && err != types.ErrDenomNotFound {
+		return nil, sdkerrors.Wrap(types.ErrInternal, "duplicate binding lookup failed")
+	}
+
+	if len(d) > 0 {
+		return nil, sdkerrors.Wrap(types.ErrDuplicateBinding, "token already bridged")
+	}
+
 	if err := k.setDenomToERC20(ctx, ci.ChainReferenceID, msg.Denom, *erc20); err != nil {
 		return nil, sdkerrors.Wrap(types.ErrInternal, err.Error())
 	}

--- a/x/skyway/types/errors.go
+++ b/x/skyway/types/errors.go
@@ -24,4 +24,5 @@ var (
 	ErrDenomNotFound            = sdkerrors.Register(ModuleName, 21, "denom not found")
 	ErrERC20NotFound            = sdkerrors.Register(ModuleName, 22, "erc20 not found")
 	ErrUnauthorized             = sdkerrors.Register(ModuleName, 23, "unauthorized")
+	ErrDuplicateBinding         = sdkerrors.Register(ModuleName, 24, "erc20 already bound to denom")
 )


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2641

# Background

This change adds a check that prevents binding a `denom` to an ERC20 address that is already bound.

> [!important]
> This will prevent updating your ERC20 addresses against your own denoms even, but it could theoretically be implemented at a later stage.

> [!warning]
> The underlaying gravity bridge code was not written with more than one remote chain in mind. Therefore, after this change, it will not be possible to use the same Ethereum address for a denom on more than one remote chain, so deterministic addresses cannot be used anymore.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
