### PR TITLE
refactor: return nil when error has already been checked

### DIFF
--- a/x/skyway/keeper/batch.go
+++ b/x/skyway/keeper/batch.go
@@ -285,7 +285,7 @@ func (k Keeper) GetOutgoingTXBatch(ctx context.Context, tokenContract types.EthA
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "found invalid batch in store")
 	}
-	return ret, err
+	return ret, nil
 }
 
 // CancelOutgoingTXBatch releases all TX in the batch and deletes the batch

--- a/x/skyway/keeper/grpc_query.go
+++ b/x/skyway/keeper/grpc_query.go
@@ -245,7 +245,7 @@ func (k Keeper) DenomToERC20(
 	var ret types.QueryDenomToERC20Response
 	ret.Erc20 = erc20.GetAddress().Hex()
 
-	return &ret, err
+	return &ret, nil
 }
 
 // ERC20ToDenom queries the ERC20 contract that maps to an Ethereum ERC20 if any


### PR DESCRIPTION
# Related Github tickets

- a list of github issues that are relevant for this PR

# Background

Since we have already checked err before and returned when err != nil, err must be nil here.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [ ] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
