### PR TITLE
chore: emit event on consensus message creation

### DIFF
--- a/util/libwasm/plugin_test.go
+++ b/util/libwasm/plugin_test.go
@@ -6,8 +6,11 @@ import (
 
 	"cosmossdk.io/log"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/v2/types"
+	"github.com/cometbft/cometbft/abci/types"
+	tmtypes "github.com/cometbft/cometbft/proto/tendermint/types"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/proto"
 	schedulerbindings "github.com/palomachain/paloma/v2/x/scheduler/bindings/types"
 	skywaybindings "github.com/palomachain/paloma/v2/x/skyway/bindings/types"
 	tfbindings "github.com/palomachain/paloma/v2/x/tokenfactory/bindings/types"
@@ -25,8 +28,19 @@ func (m *MockMessenger[T]) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddr
 	return args.Get(0).([]sdk.Event), args.Get(1).([][]byte), args.Get(2).([][]*codectypes.Any), args.Error(3)
 }
 
+var _ sdk.EventManagerI = (*mockEvtMgr)(nil)
+
+type mockEvtMgr struct{}
+
+func (m *mockEvtMgr) ABCIEvents() []types.Event                   { return nil }
+func (m *mockEvtMgr) EmitEvent(event sdk.Event)                   {}
+func (m *mockEvtMgr) EmitEvents(events sdk.Events)                {}
+func (m *mockEvtMgr) EmitTypedEvent(tev proto.Message) error      { return nil }
+func (m *mockEvtMgr) EmitTypedEvents(tevs ...proto.Message) error { return nil }
+func (m *mockEvtMgr) Events() sdk.Events                          { return nil }
+
 func TestDispatchMsg(t *testing.T) {
-	ctx := sdk.Context{}
+	ctx := sdk.NewContext(nil, tmtypes.Header{}, false, log.NewNopLogger()).WithEventManager(&mockEvtMgr{})
 	contractAddr := sdk.AccAddress([]byte("test_address"))
 	contractIBCPortID := "test_port"
 

--- a/x/evm/keeper/smart_contract_deployment.go
+++ b/x/evm/keeper/smart_contract_deployment.go
@@ -162,7 +162,7 @@ func (k Keeper) AddSmartContractExecutionToConsensus(
 		return 0, err
 	}
 
-	return k.ConsensusKeeper.PutMessageInQueue(
+	id, err := k.ConsensusKeeper.PutMessageInQueue(
 		ctx,
 		consensustypes.Queue(
 			types.ConsensusTurnstoneMessage,
@@ -182,6 +182,17 @@ func (k Keeper) AddSmartContractExecutionToConsensus(
 			RequireGasEstimation: true,
 			RequireSignatures:    true,
 		})
+	if err != nil {
+		return 0, err
+	}
+
+	keeperutil.EmitEvent(k, ctx, "add_consensus_message",
+		sdk.NewAttribute("msg_id", fmt.Sprint(id)),
+		sdk.NewAttribute("chain_reference_id", chainReferenceID),
+		sdk.NewAttribute("assignee", assignee),
+		sdk.NewAttribute("assignee_remote_addr", remoteAddr),
+	)
+	return id, nil
 }
 
 func (k Keeper) scheduleCompassHandover(


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/2725

# Background

This change ensures that any events emitted by Paloma in the context of a CW message call will be correctly attached to the transaction. For some reason, that is not the case by default.

# Testing completed

- [x] test coverage exists or has been added/updated
- [x] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [x] If there are breaking changes, there is a supporting migration.
