### PR TITLE
fix(x/skyway): use the correct `errEthereumSender` instead of `errRec…

### DIFF
--- a/x/skyway/keeper/attestation_handler.go
+++ b/x/skyway/keeper/attestation_handler.go
@@ -89,7 +89,7 @@ func (a AttestationHandler) handleSendToPaloma(ctx context.Context, claim types.
 	// likewise nil sender would have to be caused by a bogus event
 	if errEthereumSender != nil {
 		logger.WithError(errEthereumSender).Error("Invalid ethereum sender")
-		return sdkerrors.Wrap(errTokenAddress, "invalid ethereum sender on claim")
+		return sdkerrors.Wrap(errEthereumSender, "invalid ethereum sender on claim")
 	}
 
 	denom, err := a.keeper.GetDenomOfERC20(ctx, claim.GetChainReferenceId(), *tokenAddress)


### PR DESCRIPTION
…eriverAddr`

# Related Github tickets

N/A

# Background
`errTokenAddress` has been checked before, it should be nil after that
```golang
        if errTokenAddress != nil {
		logger.WithError(errTokenAddress).Error("Invalid token contract")
		return sdkerrors.Wrap(errTokenAddress, "invalid token contract on claim")
	}

	// likewise nil sender would have to be caused by a bogus event
	if errEthereumSender != nil {
		logger.WithError(errEthereumSender).Error("Invalid ethereum sender")
		return sdkerrors.Wrap(errTokenAddress, "invalid ethereum sender on claim")
	}
```
# Testing completed

- [x] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
