### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/util/libvalid/nil.go
+++ b/util/libvalid/nil.go
@@ -1,5 +1,7 @@
 package libvalid
 
+import "slices"
+
 import "unsafe"
 
 func IsNil(parameter interface{}) bool {
@@ -12,10 +14,5 @@ func NotNil(parameter interface{}) bool {
 }
 
 func AnyNil(values ...interface{}) bool {
-	for _, val := range values {
-		if IsNil(val) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(values, IsNil)
 }

--- a/x/paloma/ante.go
+++ b/x/paloma/ante.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 
 	sdkerrors "cosmossdk.io/errors"
 	"cosmossdk.io/log"
@@ -192,13 +193,7 @@ func (d GasExemptAddressDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 
 	sender := sdk.AccAddress(feeTx.FeePayer()).String()
 	params := d.k.GetParams(ctx)
-	found := false
-	for _, v := range params.GasExemptAddresses {
-		if v == sender {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(params.GasExemptAddresses, sender)
 
 	if found {
 		ctx = ctx.WithGasMeter(&freeGasMeter{})

--- a/x/skyway/keeper/keeper.go
+++ b/x/skyway/keeper/keeper.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 
 	"cosmossdk.io/core/address"
 	sdkerrors "cosmossdk.io/errors"
@@ -300,11 +301,9 @@ func (k Keeper) bridgeTaxAmount(
 		return math.ZeroInt(), nil
 	}
 
-	for _, addr := range bridgeTax.ExemptAddresses {
-		if sender.Equals(addr) {
-			// The sender is exempt from bridge tax
-			return math.ZeroInt(), nil
-		}
+	if slices.ContainsFunc(bridgeTax.ExemptAddresses, sender.Equals) {
+		// The sender is exempt from bridge tax
+		return math.ZeroInt(), nil
 	}
 
 	num := math.NewIntFromBigInt(bRate.Num())
@@ -364,11 +363,9 @@ func (k Keeper) UpdateBridgeTransferUsageWithLimit(
 		return err
 	}
 
-	for _, addr := range limits.ExemptAddresses {
-		if sender.Equals(addr) {
-			// The sender is exempt from bridge transfer limits
-			return nil
-		}
+	if slices.ContainsFunc(limits.ExemptAddresses, sender.Equals) {
+		// The sender is exempt from bridge transfer limits
+		return nil
 	}
 
 	if limits.LimitPeriod == types.LimitPeriod_NONE {

--- a/x/valset/keeper/keeper.go
+++ b/x/valset/keeper/keeper.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"sort"
 	"time"
 
@@ -461,10 +462,8 @@ func (k Keeper) GetLatestSnapshotOnChain(ctx context.Context, chainReferenceID s
 		}
 
 		// See if this snapshot is active on this chain
-		for _, chain := range snapshot.Chains {
-			if chain == chainReferenceID {
-				return snapshot, nil
-			}
+		if slices.Contains(snapshot.Chains, chainReferenceID) {
+			return snapshot, nil
 		}
 
 		snapshotId = snapshot.GetId() - 1


### PR DESCRIPTION
# Related Github tickets

https://github.com/palomachain/paloma/issues/1365

# Background

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

# Testing completed

- [ ] test coverage exists or has been added/updated
- [ ] tested in a private testnet

# Breaking changes

- [x] I have checked my code for breaking changes
- [ ] If there are breaking changes, there is a supporting migration.
